### PR TITLE
Adjust the status of Tim Berners-Lee in the TAG

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1016,7 +1016,7 @@ Composition of the Technical Architecture Group</h5>
 	for example if a chair steps down or if a minority of the participants make such a request.
 
 	As <dfn export>Director Emeritus</dfn>,
-	Tim Berners-Lee has a permanent standing invitation
+	Tim Berners-Lee has a ongoing standing invitation
 	to all regular sessions of the Technical Architecture Group,
 	and access to the [=TAG=]'s [[#tag-comm|means of communication]].
 

--- a/index.bs
+++ b/index.bs
@@ -1015,7 +1015,7 @@ Composition of the Technical Architecture Group</h5>
 	and <em class=rfc2119>may</em> be run at other times when initiated by the current chairs or the Team,
 	for example if a chair steps down or if a minority of the participants make such a request.
 
-	As <dfn export>Director Emeritus</dfn>,
+	As the <dfn export>Founder of W3C</dfn>,
 	Tim Berners-Lee has an ongoing standing invitation
 	to participate in all regular sessions and asynchronous discussions of the Technical Architecture Group,
 	and access to the [=TAG=]'s [[#tag-comm|means of communication]].

--- a/index.bs
+++ b/index.bs
@@ -1016,7 +1016,7 @@ Composition of the Technical Architecture Group</h5>
 	for example if a chair steps down or if a minority of the participants make such a request.
 
 	As <dfn export>Director Emeritus</dfn>,
-	Tim Berners-Lee has a ongoing standing invitation
+	Tim Berners-Lee has an ongoing standing invitation
 	to all regular sessions of the Technical Architecture Group,
 	and access to the [=TAG=]'s [[#tag-comm|means of communication]].
 

--- a/index.bs
+++ b/index.bs
@@ -999,9 +999,6 @@ Composition of the Technical Architecture Group</h5>
 
 	<ul>
 		<li>
-			Tim Berners-Lee, who is a life member;
-
-		<li>
 			Three participants [[#TAG-appointments|appointed by the Team]];
 
 		<li>
@@ -1017,6 +1014,11 @@ Composition of the Technical Architecture Group</h5>
 	as well as when a majority of the participants request it;
 	and <em class=rfc2119>may</em> be run at other times when initiated by the current chairs or the Team,
 	for example if a chair steps down or if a minority of the participants make such a request.
+
+	As <dfn export>Director Emeritus</dfn>,
+	Tim Berners-Lee has a permanent standing invitation
+	to all regular sessions of the Technical Architecture Group,
+	and access to the [=TAG=]'s [[#tag-comm|means of communication]].
 
 	The [=Team=] also appoints a <a href="https://www.w3.org/Guide/teamcontact/role.html">Team Contact</a> [[TEAM-CONTACT]] for the TAG,
 	as described in <a href="#ReqsAllGroups"></a>.

--- a/index.bs
+++ b/index.bs
@@ -1017,7 +1017,7 @@ Composition of the Technical Architecture Group</h5>
 
 	As <dfn export>Director Emeritus</dfn>,
 	Tim Berners-Lee has an ongoing standing invitation
-	to all regular sessions of the Technical Architecture Group,
+	to participate in all regular sessions and asynchronous discussions of the Technical Architecture Group,
 	and access to the [=TAG=]'s [[#tag-comm|means of communication]].
 
 	The [=Team=] also appoints a <a href="https://www.w3.org/Guide/teamcontact/role.html">Team Contact</a> [[TEAM-CONTACT]] for the TAG,


### PR DESCRIPTION
This ensures he has permanent access to participate in the TAG, without putting him on the critical path for any vote or quorum that involves TAG members, notably the Council's Unanimous Short Circuit.

More broadly, this also removes him from being part of the Council, as the Council's purpose is to replace his former role as Director in resolving Formal Objections.

This is one possible solution to #784, with #792 and #793 being alternatives.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/791.html" title="Last updated on Oct 25, 2024, 3:52 AM UTC (ae2e9ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/791/01bd370...frivoal:ae2e9ee.html" title="Last updated on Oct 25, 2024, 3:52 AM UTC (ae2e9ee)">Diff</a>