### PR TITLE
Limit the involvement of Tim Berners-Lee to the TAG proper

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2344,7 +2344,7 @@ Council Composition</h5>
 	Each [=W3C Council=] is composed of the following members (excepting any [[#council-participation|renounced or dismissed]]):
 	* the [=CEO=] or their chosen [=Team=] delegate
 	* the members of the [=Advisory Board=]
-	* the members of the [=Technical Architecture Group=] other than Tim Berners-Lee
+	* the elected and appointed members of the [=Technical Architecture Group=]
 
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 

--- a/index.bs
+++ b/index.bs
@@ -2344,7 +2344,7 @@ Council Composition</h5>
 	Each [=W3C Council=] is composed of the following members (excepting any [[#council-participation|renounced or dismissed]]):
 	* the [=CEO=] or their chosen [=Team=] delegate
 	* the members of the [=Advisory Board=]
-	* the members of the [=Technical Architecture Group=]
+	* the members of the [=Technical Architecture Group=] other that Tim Berners Lee
 
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 

--- a/index.bs
+++ b/index.bs
@@ -2344,7 +2344,7 @@ Council Composition</h5>
 	Each [=W3C Council=] is composed of the following members (excepting any [[#council-participation|renounced or dismissed]]):
 	* the [=CEO=] or their chosen [=Team=] delegate
 	* the members of the [=Advisory Board=]
-	* the members of the [=Technical Architecture Group=] other that Tim Berners-Lee
+	* the members of the [=Technical Architecture Group=] other than Tim Berners-Lee
 
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 

--- a/index.bs
+++ b/index.bs
@@ -2344,7 +2344,7 @@ Council Composition</h5>
 	Each [=W3C Council=] is composed of the following members (excepting any [[#council-participation|renounced or dismissed]]):
 	* the [=CEO=] or their chosen [=Team=] delegate
 	* the members of the [=Advisory Board=]
-	* the members of the [=Technical Architecture Group=] other that Tim Berners Lee
+	* the members of the [=Technical Architecture Group=] other that Tim Berners-Lee
 
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 


### PR DESCRIPTION
As the Council's purpose is to replace his former role as Director in resolving Formal Objections, this removes him from being part of the Council. This way, he does not take part in the Council's deliberations, and is not on the critical path for Council votes or quorum questions, notably the Council's Unanimous Short Circuit.

This is one possible solution to #784, with #791 and #793 being alternatives.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/792.html" title="Last updated on May 30, 2024, 2:03 PM UTC (8f0f189)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/792/01bd370...frivoal:8f0f189.html" title="Last updated on May 30, 2024, 2:03 PM UTC (8f0f189)">Diff</a>