### PR TITLE
Allow Tim Berners-Lee to abstain in Unanimous Short Circuit votes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2453,6 +2453,8 @@ Unanimous Short Circuit</h5>
 	the Team recommends a resolution
 	and every potential member of a Council who is not renouncing their seat
 	votes affirmatively (no abstentions) to adopt this resolution.
+	As an exception, Tim Berners Lee <em class=rfc2119>may</em> abstain
+	without blocking the adoption of the resolution.
 
 	This step <em class=rfc2119>may</em> be run concurrently with [[#council-participation]]
 	and prior to choosing a [=W3C Council Chair|Chair=].

--- a/index.bs
+++ b/index.bs
@@ -2453,7 +2453,7 @@ Unanimous Short Circuit</h5>
 	the Team recommends a resolution
 	and every potential member of a Council who is not renouncing their seat
 	votes affirmatively (no abstentions) to adopt this resolution.
-	As an exception, Tim Berners Lee <em class=rfc2119>may</em> abstain
+	As an exception, Tim Berners-Lee <em class=rfc2119>may</em> abstain
 	without blocking the adoption of the resolution.
 
 	This step <em class=rfc2119>may</em> be run concurrently with [[#council-participation]]


### PR DESCRIPTION
This removes him from the being on critical path for the Council's Unanimous Short Circuit votes, without affecting any other role he has as a TAG and Council member.

This is one possible solution to #784, with #791 and #792 being alternatives.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 7, 2024, 6:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL]([object Object])

```
Error running preprocessor, returned code: 2.
Your document appears to use tabs to indent, but line 2540 starts with spaces.
FATAL ERROR: Line 2540 isn't indented enough (needs 2 indents) to be valid Markdown:
"      (in addition, Tim Berners-Lee &lt;em bs-line-number=2540 class="rfc2119">may&lt;/em> also abstain)"
LINK ERROR: No 'dfn' refs found for 'advisory committee override'.
[=Advisory Committee Override=]
 ✘  Did not generate, due to errors exceeding the allowed error level.
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/process%23793.)._
</details>
