### PR TITLE
Retire Proposed Recommendation

### DIFF
--- a/basic-rec-track.svg
+++ b/basic-rec-track.svg
@@ -1,4 +1,4 @@
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 30 630 180" width="100%">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 30 457 175" width="100%">
 			<title>Basic W3C Recommendation Track</title>
 			<!-- basic maturity states -->
 			<g role="list">
@@ -56,7 +56,7 @@
 				</g>
 			<!-- CRS -->
 				<g role="listitem">
-					<a href="#pr-1">
+					<a href="#rec-1">
 						<ellipse role="img" id="cr-1" ry="18" rx="38" cy="140" cx="260" stroke="black" fill="#fff">
 						<title>Candidate Recommendation Snapshot (CRS) - Patent Policy exclusion opportunity</title>
 						</ellipse>
@@ -90,11 +90,11 @@
 								<path stroke="#000" d="M242,124C238,114 244,104 260,104 271,104 285,108 286,117" stroke-dasharray="6 2" fill="none"></path>
 							</a>
 						</g>
-					<!-- Advance to PR -->
+					<!-- Advance to REC -->
 						<g role="listitem" fill="#060">
-						<a href="#pr-1">
+						<a href="#rec-1">
 							<g role="img">
-							<title>Advance to Proposed Recommendation</title>
+							<title>Advance to Recommendation</title>
 							</g>
 							<text x="298" y="121" font-size="8">WG Decision +</text>
 							<text x="298" y="129" font-size="8">Team Approval +</text>
@@ -158,38 +158,25 @@
 						</g>
 					</g>
 				</g>
-			<!-- PR -->
+			<!-- REC -->
 				<g role="listitem">
 					<a href="#rec-1">
-						<ellipse role="img" id="pr-1" ry="18" rx="28" cy="140" cx="413" stroke="black" fill="#fff">
-						<title>Proposed Recommendation (PR) — AC Review</title>
+						<ellipse role="img" id="rec-1" ry="18" rx="28" cy="140" cx="413" stroke="black" fill="#fff" stroke-width="2">
+						<title>Recommendation</title>
 						</ellipse>
 						<text aria-hidden="true" font-size="14" font-weight="bold"
-						      y="144" x="413" text-anchor="middle">PR</text>
-						<text area-hidden="true" font-size="6" y="150" x="413" text-anchor="middle">AC Review</text>
+						      y="144" x="413" text-anchor="middle">REC</text>
 					</a>
 					<g role="list">
-					<!-- Advance to Rec -->
-						<g role="listitem" fill="#060">
-							<a href="#rec-1">
-								<g role="img">
-									<title>Advance to Recommendation</title>
-								</g>
-								<text x="300" y="138" font-size="8">
-									<tspan x="445" y="134">W3C Decision</tspan>
-								</text>
-								<path d="M441,140h100" stroke="#060"></path>
-								<polygon points="534,136 544,140 534,144"></polygon>
-							</a>
-						</g>
 					<!-- Return to CRS -->
 						<g role="listitem" fill="#900">
 							<a href="#cr-1">
 								<g role="img">
 									<title>Return to Candidate Recommendation Snapshot</title>
 								</g>
-								<text font-size="8" text-anchor="end">
-									<tspan x="385" y="160">W3C Decision</tspan>
+								<text font-size="8" text-anchor="start">
+									<tspan x="342" y="157">WG Decision</tspan>
+									<tspan x="342" y="165" font-size="6">(or Team Decision with AB+TAG Approval)</tspan>
 								</text>
 								<path d="M301,147h88" stroke-dasharray="4 4" stroke="#900"></path>
 								<polygon points="301,145 296,147 301,149"></polygon>
@@ -201,22 +188,15 @@
 								<g role="img">
 									<title>Return to Working Draft</title>
 								</g>
-								<text font-size="8" text-anchor="end">
-									<tspan x="410" y="185">W3C Decision</tspan>
+								<text font-size="8" text-anchor="start">
+									<tspan x="342" y="157">WG Decision</tspan>
+									<tspan x="342" y="165" font-size="6">(or Team Decision with AB+TAG Approval)</tspan>
 								</text>
-								<path d="M413,158v32h-316v-26" stroke-dasharray="4 4" stroke="#900" fill="none"></path>
+								<path d="M339,147v41h-242v-26" stroke-dasharray="4 4" stroke="#900" fill="none"></path>
 								<polygon points="95,164 97,159 99,164"></polygon>
 							</a>
 						</g>
 					</g>
-				</g>
-			<!-- Rec -->
-				<g role="listitem">
-					<ellipse role="img" id="rec-1" ry="18" rx="28" cy="140" cx="573" stroke="black" fill="#fff" stroke-width="2">
-						<title>Recommendation (Rec)</title>
-					</ellipse>
-					<text aria-hidden="true" font-size="16" font-weight="bold"
-					      y="144" x="573" text-anchor="middle" stroke-width=".3">REC</text>
 				</g>
 			</g>
 		</svg>

--- a/index.bs
+++ b/index.bs
@@ -719,8 +719,8 @@ Role of the Advisory Committee</h4>
 		<li>
 			<a href="#ACReview">reviewing formal proposals</a> of W3C:
 			<a href="#CharterReview">Charter Proposals</a>,
-			<a href="#RecsPR">Proposed Recommendations</a>,
-			and <a href="#GAProcess">Proposed Process Documents</a>.
+			<a href="#transition-rec">transitions to Recommendation</a>,
+			and <a href="#GAProcess">proposed Process Documents</a>.
 
 		<li>
 			electing the <a href="#AB">Advisory Board</a> participants other than the Advisory Board Chair.
@@ -2702,11 +2702,16 @@ Determining the W3C Decision</h4>
 	those other conditions must also be re-fulfilled.
 
 	<div class="example">
-		For example, to make [=substantive changes=] to a [=Proposed Recommendations=],
-		the [=technical report=] could be returned to [=Candidate Recommendation=].
+		For example, if [=substantive changes=] to a [=technical report=]
+		are requested when assessing the transition from
+		[=Candidate Recommendation=] to [=Recommendation=],
+		the technical report would need to go through a new [=Update Request=]
+		and be republished as a new [=Candidate Recommendation=];
+		that new version would then need to satisfy the criteria for advancement.
 		Alternatively, the desired changes can be introduced as non-substantive amendments
 		using the process for [[#revising-rec|revising a Recommendation]].
-		However, they cannot be directly integrated between [=PR=] and [=REC=],
+		However, with the exception of the removal of at-risk features,
+		they cannot be directly integrated between [=CRS=] and [=REC=],
 		because that would fail to trigger a patent exclusion opportunity.
 	</div>
 
@@ -3229,12 +3234,11 @@ The W3C Recommendation Track</h3>
 		<li>Publication of the [=First Public Working Draft=].
 		<li>Publication of zero or more revised [=Working Drafts=].
 		<li>Publication of one or more [=Candidate Recommendations=].
-		<li>Publication of a [=Proposed Recommendation=].
 		<li>Publication as a [=W3C Recommendation=].
 	</ol>
 
 	A <dfn export lt="W3C Recommendation Track document | REC Track document | Recommendation Track document | Recommendation-track document">W3C Recommendation Track document</dfn>
-	is any document whose current status is one of the five in the numbered list above.
+	is any document whose current status is one of the four in the numbered list above.
 
 	<div role="region" aria-label="Basic W3C Recommendation Track">
 		<pre class=include-raw>
@@ -3376,20 +3380,6 @@ Maturity Stages on the Recommendation Track</h4>
 			for implication on patent licensing obligations.
 
 		<dt>
-			<dfn export id="RecsPR" lt="W3C Proposed Recommendation | Proposed Recommendation | PR">Proposed Recommendation</dfn> (<abbr>PR</abbr>)
-		<dd>
-			A Proposed Recommendation is a document
-			that has been accepted by W3C
-			as of sufficient quality to become a [=W3C Recommendation=].
-			This phase triggers formal review by the [=Advisory Committee=],
-			who <em class="rfc2119">may</em> recommend
-			that the document be [=published=] as a [=W3C Recommendation=],
-			returned to the [=Working Group=] for further work,
-			or abandoned.
-			[=Substantive changes=] <em class="rfc2119">must not</em> be made to a [=Proposed Recommendation=]
-			except by [=publishing=] a new [=Working Draft=] or [=Candidate Recommendation=].
-
-		<dt>
 			<dfn id="RecsW3C" export lt="W3C Recommendation | Recommendation | REC">W3C Recommendation</dfn> (<abbr>REC</abbr>)
 		<dd>
 			A W3C Recommendation is a specification
@@ -3402,6 +3392,20 @@ Maturity Stages on the Recommendation Track</h4>
 			The W3C Royalty-Free IPR licenses
 			granted under the W3C Patent Policy [[PATENT-POLICY]]
 			apply to [=W3C Recommendations=].
+
+			<p id="expandable-rec">
+			After its initial publication,
+			a [=W3C Recommendation=] <em class=rfc2119>may</em> be [[#revising-rec|revised]]
+			to address [=editorial change|editorial=] or [=substantive change|substantive=] issues
+			that are discovered later.
+			However, <a href=#class-4>new features</a> can only be added
+			if the document already identifies itself
+			as intending to <dfn>allow new features</dfn>.
+			Such an allowance cannot be added
+			to a [=technical report=] previously published as a [=Recommendation=]
+			that did not allow such changes;
+			this requires a new [=technical report=], that could, for example, be similarly named but with an incremented version number.
+
 			As technology evolves,
 			a [=W3C Recommendation=] may become:
 			<dl>
@@ -3572,7 +3576,7 @@ Advancement on the Recommendation Track</h4>
 	so many requirements do not apply,
 	and verification is normally fairly straightforward.
 	For later stages,
-	especially transition to [=Candidate Recommendation|Candidate=] or [=Proposed Recommendation=],
+	especially transitions to [=Candidate Recommendation|Candidate=] or [=Recommendation=],
 	there is usually a formal review meeting
 	to verify that the requirements have been met.
 
@@ -3753,8 +3757,8 @@ Transitioning to Candidate Recommendation</h4>
 		<li>
 			<em class="rfc2119">may</em> identify features in the document as <dfn export>at risk</dfn>.
 			These features <em class="rfc2119">may</em> be removed
-			before advancement to [=Proposed Recommendation=]
-			without a requirement to publish a new [=Candidate Recommendation=].
+			before advancement to [=Recommendation=]
+			without requiring an [=Update Request=].
 	</ul>
 
 	The first Candidate Recommendation publication
@@ -3771,7 +3775,7 @@ Transitioning to Candidate Recommendation</h4>
 		<li>Return to <a href="#revising-wd">Working Draft</a></li>
 		<li>A revised <a href="#publishing-crrs">Candidate Recommendation Snapshot</a></li>
 		<li>A revised <a href="#publishing-crud">Candidate Recommendation Draft</a></li>
-		<li><a href="#transition-pr">Proposed Recommendation</a></li>
+		<li><a href="#transition-pr">Recommendation</a></li>
 		<li><a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
@@ -3801,8 +3805,8 @@ Publishing a [=Candidate Recommendation Snapshot=]</h5>
 		<li>
 			<em class="rfc2119">may</em> identify features in the document as [=at risk=].
 			These features <em class="rfc2119">may</em> be removed
-			before advancement to [=Proposed Recommendation=]
-			without a requirement to publish a new [=Candidate Recommendation=].
+			before advancement to [=Recommendation=]
+			without requiring an [=Update Request=].
 	</ul>
 
 	The [=Team=] <em class="rfc2119">must</em> announce
@@ -3876,45 +3880,44 @@ Publishing a [=Candidate Recommendation Draft=]</h5>
 		<li>Return to <a href="#revising-wd">Working Draft</a></li>
 		<li>A revised <a href="#publishing-crrs">Candidate Recommendation Snapshot</a></li>
 		<li>A revised <a href="#publishing-crud">Candidate Recommendation Draft</a></li>
-		<li><a href="#transition-pr">Proposed Recommendation</a>,
+		<li><a href="#transition-pr">Recommendation</a>,
 		if there are no [=substantive change=] other than dropping [=at risk=] features</li>
 		<li><a href="#abandon-draft">Discontinued Draft</a></li>
 	</ul>
 
+<h4 id="transition-rec" oldids="rec-publication, rec-pr, transition-pr, RecsPR">
+Transitioning to Recommendation</h4>
 
-<h4 id=transition-pr oldids="rec-pr">
-Transitioning to Proposed Recommendation</h4>
+	When a [=Working Group=] estimates
+	that a [=Candidate Recommendation=] has fulfilled all the relevant criteria,
+	it <em class=rfc2119>may</em> [=group decision|decide=] to request advancement to [=W3C Recommendation=].
 
 	In addition to meeting the <a href="#transition-reqs">requirements for advancement</a>,
-
-	<ul>
-		<li>
-			The status information <em class="rfc2119">must</em> specify the deadline for [=Advisory Committee review=],
-			which <em class="rfc2119">must</em> be <strong>at least</strong> 28 days
-			after the publication of the [=Proposed Recommendation=]
-			and <em class="rfc2119">should</em> be at least 10 days
-			after the end of the last Exclusion Opportunity
-			per ”Exclusion From W3C RF Licensing Requirements”
-			in the W3C Patent Policy [[!PATENT-POLICY]].
-	</ul>
-
-	A Working Group:
+	the Working Group:
 
 	<ul>
 		<li>
 			<em class="rfc2119">must</em> show [=adequate implementation experience=]
-			except where an exception is approved by a [=Team Decision=],
+			except where an exception is approved by a [=Team Decision=].
+
+			The [=Team=] <em class="rfc2119">may</em> approve a [=Candidate Recommendation=]
+			with minimal <a href="#implementation-experience">implementation experience</a>
+			where there is a compelling reason to do so.
+			In such a case, the [=Team=] <em class="rfc2119">must</em> explain the reasons for that decision,
+			and that information <em class=rfc2119>must</em> be included in the [=Call for Review=]
+			proposing advancement to [=W3C Recommendation=].
+
 		<li>
-			<em class="rfc2119">must</em> show that the document has received [=wide review=],
+			<em class="rfc2119">must</em> show that the document has received [=wide review=].
 
 		<li>
 			<em class="rfc2119">must</em> show that all issues
 			raised during the [=Candidate Recommendation review period=]
-			have been [=formally addressed=],
+			have been [=formally addressed=].
 
 		<li>
 			<em class="rfc2119">must </em>identify any substantive issues
-			raised since the close of the [=Candidate Recommendation review period=],
+			raised since the close of the [=Candidate Recommendation review period=].
 
 		<li>
 			<em class=rfc2119>must not</em> have made any [=substantive changes=] to the document
@@ -3925,97 +3928,43 @@ Transitioning to Proposed Recommendation</h4>
 			<em class="rfc2119">may</em> have removed features
 			identified in the [=Candidate Recommendation Snapshot=] document as [=at risk=]
 			without republishing the specification as a [=Candidate Recommendation Snapshot=].
+
+		<li>
+			<em class="rfc2119">must</em> identify, in the document, where errata are tracked.
 	</ul>
 
-	The [=Team=]:
+	Additionally,
+	if the document has previously been published as a [=W3C Recommendation=], the [=Working Group=]
+	<em class=rfc2119>must not</em> include any <a href="#correction-classes">class 4 change</a>
+	to that publication
+	unless it was explicitly marked as [=allowing new features=],
+	and <em class=rfc2119>must not</em> include any such marking
+	if not already present.
 
-	<ul>
-		<li>
-			<em class="rfc2119">must</em> announce the publication of a [=Proposed Recommendation=]
-			to the <a href="#AC">Advisory Committee</a>,
-			and <em class="rfc2119">must</em> begin an [=Advisory Committee Review=]
-			on the question of whether the specification is appropriate to [=publish=] as a [=W3C Recommendation=].
+	If all the criteria above are fulfilled,
+	the [=Team=] <em class="rfc2119">must</em> begin an [=Advisory Committee Review=]
+	on the question of whether the specification is appropriate to [=publish=] as a [=W3C Recommendation=].
+	The deadline for [=Advisory Committee review=]
+	<em class="rfc2119">must</em> allow <strong>at least</strong> 28 days,
+	and <em class="rfc2119">should</em> end at least 10 days
+	after the end of the last Exclusion Opportunity
+	per ”Exclusion From W3C RF Licensing Requirements”
+	in the W3C Patent Policy [[!PATENT-POLICY]].
 
-		<li>
-			<em class="rfc2119">may</em> approve a [=Proposed Recommendation=]
-			with minimal <a href="#implementation-experience">implementation experience</a>
-			where there is a compelling reason to do so.
-			In such a case, the [=Team=] <em class="rfc2119">must</em> explain the reasons for that decision,
-			and that information <em class=rfc2119>must</em> be included in the [=Call for Review=]
-			proposing advancement to [=W3C Recommendation=].
-	</ul>
-
-	Since a [=W3C Recommendation=] <em class="rfc2119">must not</em> include any [=substantive changes=]
-	from the [=Proposed Recommendation=] it is based on,
-	to make any [=substantive change=] to a [=Proposed Recommendation=]
-	the [=Working Group=] <em class="rfc2119">must</em> return the specification to [=Candidate Recommendation=]
-	or [=Working Draft=].
-
-	<p id="expandable-rec">
-	A [=Proposed Recommendation=] may identify itself
-	as intending to <dfn>allow new features</dfn>
-	(<a href="#correction-classes">class 4 changes</a>)
-	after its initial publication as a [=Recommendation=],
-	as described in [[#revised-rec-features]].
-	Such an allowance cannot be added
-	to a [=technical report=] previously published as a [=Recommendation=]
-	that did not allow such changes.
-
-	Possible Next Steps:
-
-	<ul>
-		<li>
-			Return to <a href="#revising-wd">Working Draft</a>
-
-		<li>
-			Return to <a href="#transition-cr">Candidate Recommendation</a>
-
-		<li>
-			<a href="#transition-rec">Recommendation status</a>,
-			(the expected next step).
-
-		<li>
-			<a href="#abandon-draft">Discontinued Draft</a></li>
-	</ul>
-
-	[=Advisory Committee representatives=] <em class="rfc2119">may</em> initiate an [=Advisory Committee Appeal=]
-	of the decision to advance the technical report.
-
-<h4 id="transition-rec" oldids="rec-publication">
-Transitioning to W3C Recommendation</h4>
+	If there was any [=dissent=] in Advisory Committee reviews,
+	the [=Team=] <em class="rfc2119">must</em> publish the substantive content of the dissent
+	to W3C and the general public,
+	and <em class="rfc2119">must</em> [=formally address=] the comment
+	at least 14 days before publication as a [=W3C Recommendation=].
 
 	The decision to advance a document to [=Recommendation=]
 	is a [=W3C Decision=].
-
-	In addition to meeting the <a href="#transition-reqs">requirements for advancement</a>,
-
-	<ul>
-		<li>
-			A [=Recommendation=] <em class="rfc2119">must</em> identify where errata are tracked, and
-
-		<li>
-			A [=Recommendation=] <em class="rfc2119">must not</em> include any [=substantive changes=]
-			from the [=Proposed Recommendation=]
-			on which it is based.
-
-		<li>
-			If there was any [=dissent=] in Advisory Committee reviews,
-			the [=Team=] <em class="rfc2119">must</em> publish the substantive content of the dissent
-			to W3C and the general public,
-			and <em class="rfc2119">must</em> [=formally address=] the comment
-			at least 14 days before publication as a [=W3C Recommendation=].
-
-		<li>
-			[=Advisory Committee representatives=] <em class="rfc2119">may</em> initiate
-			an [=Advisory Committee Appeal=]
-			of the [=W3C decision=]
-
-		<li>
-			The [=Team=] <em class="rfc2119">must</em> announce the publication of a [=W3C Recommendation=]
-			to <a href="#AC">Advisory Committee</a>,
-			other W3C groups
-			and to the public.
-	</ul>
+	The [=Team=] <em class="rfc2119">must</em> announce the publication of a [=W3C Recommendation=]
+	to the <a href="#AC">Advisory Committee</a>,
+	to other W3C groups
+	and to the public.
+	[=Advisory Committee representatives=] <em class="rfc2119">may</em> initiate an [=Advisory Committee Appeal=]
+	of the decision to advance the technical report.
 
 	Possible next steps:
 	A [=W3C Recommendation=] normally retains its status indefinitely.
@@ -4027,6 +3976,7 @@ Transitioning to W3C Recommendation</h4>
 
 		<li>
 			republished as a <a href="#transition-cr">Candidate Recommendation</a>
+			or <a href="https://www.w3.org/2023/Process-20231103/#revising-wd">Working Draft</a>
 			to be developed towards a revised [=Recommendation=], or
 
 		<li>
@@ -4709,15 +4659,9 @@ Publishing Registries</h4>
 			<dfn export>Obsolete Registry</dfn> and <dfn export>Superseded Registry</dfn>.
 
 		<li>
-			There is no equivalent to the Proposed Recommendation phase.
-			Instead,
-			an [=Advisory Committee Review=] is started
-			upon publication of each [=Candidate Registry Snapshot=].
-
-		<li>
-			Changes that add new features (i.e. [[#correction-classes|class 4 changes]]) are allowed
+			Changes that add new features (i.e., [[#correction-classes|class 4 changes]]) are allowed
 			in all [=W3C Registries=],
-			without needing the to explicitly indicate that this is allowed.
+			without needing them to explicitly indicate that this is allowed.
 	</ul>
 
 <h4 id=reg-table-update>


### PR DESCRIPTION
As discussed in #861, the Proposed Recommendation phase of the REC track exists only to support an AC Review during the transition of a document from CR to REC. We can simplify the Process a good deal by doing away with Proposed Recommendation entirely, and doing the AC Review on the CR that we want to promote to REC. Then, if the AC Review is successful (in addition to the other criteria), we could publish the REC directly.

This Pull Request does just that. It keeps all the criteria that were present at the CR→PR transition, as well those of the PR→REC transition, and combines them into a CR→REC transition.

This allows for a simplification of terminology, a simplification of Process text, a reduction in the number of states described in the REC track diagram, and a reduction of work needed by the WG and the Team (one transition to request instead of two, one less publication to make); all without any changes about what is expected of a Recommendation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/868.html" title="Last updated on Aug 15, 2024, 1:30 PM UTC (45c71ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/868/8b48f80...frivoal:45c71ab.html" title="Last updated on Aug 15, 2024, 1:30 PM UTC (45c71ab)">Diff</a>