### PR TITLE
Remove note about AC consensus assessment

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2038,9 +2038,6 @@ Consensus</h4>
 	or <a href="#distributed-meeting">distributed</a>)
 	as well as through <a href=#discussion-archiving>persistent text-based discussions</a>.
 
-	Note: The CEO has the role of
-	assessing consensus within the Advisory Committee.
-
 	The following terms are used in this document
 	to describe the level of support for a decision among a set of eligible individuals:
 


### PR DESCRIPTION
Assessing the consensus of the AC in AC reviews is overseen by the Team as a whole, not by the CEO singularly. Assessing the consensus of the AC outside of an AC Review is not something any of our processes depend on, so discussing who is responsible for it is unnecessary (and the phrasing is clumsy anyway).

See #615


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/875.html" title="Last updated on May 21, 2024, 2:12 AM UTC (1eb9f4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/w3process/875/8b48f80...frivoal:1eb9f4e.html" title="Last updated on May 21, 2024, 2:12 AM UTC (1eb9f4e)">Diff</a>