### PR TITLE
Relax the criteria for short-circuit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2459,8 +2459,8 @@ Short Circuit</h5>
 	The full Council process <em class=rfc2119>may</em> be short-circuited if
 	the Team recommends a resolution
 	and potential members of a Council who are not renouncing their seat
-	confirm it in the following way:
-	* at least 80% vote affirmatively to adopt this resolution, and
+	confirm it by a vote which results in both of the following:
+	* at least 80% of them vote affirmatively to adopt this resolution
 	* none of them vote against adopting the resolution
 
 	The request for confirmation <em class=rfc2119>must</em> be open for two weeks,

--- a/index.bs
+++ b/index.bs
@@ -2463,7 +2463,7 @@ Short Circuit</h5>
 	* at least 80% of them vote affirmatively to adopt this resolution
 	* none of them vote against adopting the resolution
 
-	The request for confirmation <em class=rfc2119>must</em> be open for two weeks,
+	The request for confirmation <em class=rfc2119>must</em> be open for a period of at least two weeks,
 	or until every potential member of the Council not renouncing their seat
 	has voted,
 	whichever is shortest.

--- a/index.bs
+++ b/index.bs
@@ -2465,7 +2465,7 @@ Short Circuit</h5>
 
 	The request for confirmation <em class=rfc2119>must</em> be open for two weeks,
 	or until every potential member of the Council not renouncing their seat
-	has responded (including explicit votes to abstain),
+	has voted,
 	whichever is shortest.
 
 	This step <em class=rfc2119>may</em> be run concurrently with [[#council-participation]]

--- a/index.bs
+++ b/index.bs
@@ -2453,13 +2453,20 @@ Council Participation, Dismissal, and Renunciation</h5>
 	as they can of anyone else in the W3C community.
 
 <h5 id=council-short-circuit>
-Unanimous Short Circuit</h5>
+Short Circuit</h5>
 
 
 	The full Council process <em class=rfc2119>may</em> be short-circuited if
 	the Team recommends a resolution
-	and every potential member of a Council who is not renouncing their seat
-	votes affirmatively (no abstentions) to adopt this resolution.
+	and potential members of a Council who are not renouncing their seat
+	confirm it in the following way:
+	* at least 80% vote affirmatively to adopt this resolution, and
+	* none of them vote against adopting the resolution
+
+	The request for confirmation <em class=rfc2119>must</em> be open for two weeks,
+	or until every potential member of the Council not renouncing their seat
+	has responded (including explicit votes to abstain),
+	which ever is shortest.
 
 	This step <em class=rfc2119>may</em> be run concurrently with [[#council-participation]]
 	and prior to choosing a [=W3C Council Chair|Chair=].

--- a/index.bs
+++ b/index.bs
@@ -2466,7 +2466,7 @@ Short Circuit</h5>
 	The request for confirmation <em class=rfc2119>must</em> be open for two weeks,
 	or until every potential member of the Council not renouncing their seat
 	has responded (including explicit votes to abstain),
-	which ever is shortest.
+	whichever is shortest.
 
 	This step <em class=rfc2119>may</em> be run concurrently with [[#council-participation]]
 	and prior to choosing a [=W3C Council Chair|Chair=].


### PR DESCRIPTION
A high bar for support remains needed, and any dissent remains sufficient to defeat the short-circuit proposal, but unanimity is no longer required.

See https://github.com/w3c/process/issues/852


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/885.html" title="Last updated on Jul 10, 2024, 3:31 PM UTC (4bd549e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/885/50ce7b7...frivoal:4bd549e.html" title="Last updated on Jul 10, 2024, 3:31 PM UTC (4bd549e)">Diff</a>