### PR TITLE
Add back language about substantive changes invalidating previous review

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3084,6 +3084,11 @@ Classes of Changes</h4>
 			Changes that add, remove, or alter [=registry entries=] in a [=registry table=].
 	</dl>
 
+        [=substantive changes|Substantive changes=] to a specification, as
+        enumerated in the contents of items #3 and #4 are, in other words,
+        changes that might invalidate anyone’s previous review or implementation
+        of the specification.
+
 <h4 id="errata">
 Errata Management</h4>
 


### PR DESCRIPTION
Previous versions of the Process doc contained language about substantive changes being changes that “invalidate” previous review or implementation of a spec. But somewhere along the way, that language got dropped. But it’s very useful language which helps to make things more clear to readers. So, the patch in this PR adds that language back.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/process/pull/887.html" title="Last updated on Jun 18, 2024, 8:35 AM UTC (18d2ba7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/887/50ce7b7...18d2ba7.html" title="Last updated on Jun 18, 2024, 8:35 AM UTC (18d2ba7)">Diff</a>