### PR TITLE
Intro: State some high-level goals related to WGs and their specs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -190,7 +190,7 @@ Introduction</h2>
 
 		<li>
 			Enable [=Working Groups=] to earn formal endorsement of their specifications
-			from the W3C and its Members — when their specifications meet the requirements to
+			from the W3C and its Members when their specifications meet the requirements to
 			be [=published=] as [=W3C Recommendations=].
 	</ul>
 

--- a/index.bs
+++ b/index.bs
@@ -174,8 +174,8 @@ Introduction</h2>
 	and help ensure each group's proper integration with the rest of W3C.
 
 	W3C’s technical standards, called [=W3C Recommendations=],
-	are developed by its [=Working Groups=] — and some high-level goals
-	of the W3C Process related to that development include:
+	are developed by its [=Working Groups=]. Some high-level goals
+	of the W3C Process related to that development include the following:
 
 	<ul>
 		<li>

--- a/index.bs
+++ b/index.bs
@@ -181,7 +181,7 @@ Introduction</h2>
 		<li>
 			Enable [=Working Groups=] to [=published|publish=] their [=technical reports|Technical Reports=]
 			(that is, their specifications and guidelines) on the
-			<a href="https://www.w3.org/TR/">W3C's Technical Reports page</a> — while those are in
+			<a href="https://www.w3.org/TR/">W3C's Technical Reports page</a> at
 			[[#maturity-stages|various stages of development]]. [[TR]]
 
 		<li>

--- a/index.bs
+++ b/index.bs
@@ -174,7 +174,28 @@ Introduction</h2>
 	and help ensure each group's proper integration with the rest of W3C.
 
 	W3C’s technical standards, called [=W3C Recommendations=],
-	are developed by its [=Working Groups=];
+	are developed by its [=Working Groups=] — and some high-level goals
+	of the W3C Process related to that development include:
+
+	<ul>
+		<li>
+			Enable [=Working Groups=] to [=published|publish=] their [=technical reports|Technical Reports=]
+			(that is, their specifications and guidelines) on the
+			<a href="https://www.w3.org/TR/">W3C's Technical Reports page</a> — while those are in
+			[[#maturity-stages|various stages of development]]. [[TR]]
+
+		<li>
+			Enable [=Working Groups=] to secure Royalty-Free Licensing Commitments
+			(as defined in the W3C Patent Policy) for their specifications. [[!PATENT-POLICY]]
+
+		<li>
+			Enable [=Working Groups=] to earn formal endorsement of their specifications
+			from the W3C and its Members — when their specifications meet the requirements to
+			be [=published=] as [=W3C Recommendations=].
+	</ul>
+
+
+	Along with [=W3C Recommendations=],
 	W3C also has other types of publications,
 	all described in [[#Reports]].
 	W3C has various types of groups;


### PR DESCRIPTION
I’ve had recent discussions with a handful of different chairs and editors and some other Working Group key members, to try to identify what specific things they want to get from the W3C — in other words, their reasons for choosing to do their work at the W3C, rather than somewhere else.

So the three high-level goals that this patch adds to the Introduction section represent the three key reasons that those people have actually expressed to me for choosing the W3C as the home for their work.

The _“Enable Working Groups to publish their Technical Reports (that is, their specifications and guidelines) on the W3C’s Technical Reports page”_ goal may seem like something obvious that’s not necessary to state — but it is in fact the _main_ reason that some people have told me they’ve chosen the W3C.

Specifically, some have said — for better or worse — that they don’t care about the getting the RF licensing commitments, and they don’t care about getting the endorsement of the W3C and the Membership for their specs.

Those people seem to see having a spec published with a W3C URL as a carrying more authority than a spec published elsewhere — greater market recognition (or however would be a good way to word it).

But some other people have said they (and their companies, and their companies’ lawyers…) _do_ place very great value on getting the RF licensing commitments at the W3C. (And incidentally, some have said they believe the RF licensing commitments and disclosure obligations that can be secured at the W3C are much stronger than any that they might get by publishing their specs elsewhere).

Anyway, I hope all that helps to clarify the context for this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/process/pull/894.html" title="Last updated on Oct 8, 2024, 1:16 AM UTC (5b17aad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/894/538646f...5b17aad.html" title="Last updated on Oct 8, 2024, 1:16 AM UTC (5b17aad)">Diff</a>