### PR TITLE
Note that “Candidate” means “eligible” for further-advancement consideration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3316,13 +3316,20 @@ Maturity Stages on the Recommendation Track</h4>
 			and that no further refinement to the text is expected
 			without additional implementation experience and testing;
 			however, additional features might be expected in a later revision.
-			A [=Candidate Recommendation=] is expected to be as well-written,
+			The word <em>Candidate</em> in [=Candidate Recommendation=] signals
+			that the document is <em>eligible</em> for evaluation against the
+			requirements for further advancement — but does not indicate that
+			the Working Group is necessarily <em>intending</em> further advancement,
+			nor that the Working Group necessarily believes the document already meets
+			the requirements for further advancement. But a [=Candidate Recommendation=]
+			is expected to be as well-written,
 			detailed,
 			self-consistent,
 			and technically complete
 			as a [=Recommendation=],
 			and acceptable as such
-			if and when the requirements for further advancement are met.
+			if and when the requirements for further advancement <em>are</em> met.
+
 
 			Candidate Recommendation publications take one of two forms:
 


### PR DESCRIPTION
Fixes https://github.com/w3c/process/issues/402. This change makes _“Candidate Recommendation”_ an accurate term even in the case where a Working Group has indicated they don’t intend to advance to REC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/process/pull/895.html" title="Last updated on Jun 24, 2024, 3:07 AM UTC (151bf30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/895/538646f...151bf30.html" title="Last updated on Jun 24, 2024, 3:07 AM UTC (151bf30)">Diff</a>