### PR TITLE
Set up progressive vote threshold depending on participation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2800,8 +2800,22 @@ Appeal by Advisory Committee Representatives</h3>
 	and “Abstain”,
 	together with Comments.
 
-	If the number of votes to reject
-	exceeds the number of votes to approve,
+	The level of support needed for a [=Advisory Committee Override=] to pass
+	depends on the level of participation by [=Advisory Committee Representatives=],
+	(including those who cast an explicit “abstain” ballot):
+	* if fewer than 5% participate,
+		the vote fails.
+	* if at least 5% but no more than 15% participate,
+		and the number of “Approve” ballots exceeds three times (3x) the number of “Reject” ballots,
+		the vote passes.
+	* if more than 15% but fewer than 20% participate,
+		and the number of “Approve” ballots exceeds twice (2x) the number of “Reject” ballots,
+		the vote passes.
+	* if 20% or more participate,
+		and the number of “Approve” ballots exceeds the number of “Reject” ballots,
+		the vote passes.
+
+	If the vote passes,
 	the decision is overturned.
 	In that case, there are the following possible next steps:
 

--- a/index.bs
+++ b/index.bs
@@ -2800,7 +2800,7 @@ Appeal by Advisory Committee Representatives</h3>
 	and “Abstain”,
 	together with Comments.
 
-	The level of support needed for a [=Advisory Committee Override=] to pass
+	The level of support needed for an [=Advisory Committee Override=] to pass
 	depends on the level of participation by [=Advisory Committee Representatives=],
 	(including those who cast an explicit “abstain” ballot):
 	* if fewer than 5% participate,

--- a/index.bs
+++ b/index.bs
@@ -2801,8 +2801,9 @@ Appeal by Advisory Committee Representatives</h3>
 	together with Comments.
 
 	The level of support needed for an [=Advisory Committee Override=] to pass
-	depends on the level of participation by [=Advisory Committee Representatives=],
-	(including those who cast an explicit “abstain” ballot):
+	depends on the level of ballot participation 
+	(including explicit “abstain” ballots) 
+	by [=Advisory Committee Representatives=]:
 	* if fewer than 5% participate,
 		the vote fails.
 	* if at least 5% but no more than 15% participate,


### PR DESCRIPTION
This mirrors the "requisite member vote" process from the W3C bylaws, and avoids making momentous decisions based on a slim majority in vote with low participation. Also includes a minimum quorum.

See https://www.w3.org/2024/07/15-ab-minutes.html#r02

Closes https://github.com/w3c/process/issues/886


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/901.html" title="Last updated on Jul 17, 2024, 3:11 PM UTC (a5cc25c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/901/5a60ea5...frivoal:a5cc25c.html" title="Last updated on Jul 17, 2024, 3:11 PM UTC (a5cc25c)">Diff</a>