### PR TITLE
short-circuit drop Team-related votes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2534,7 +2534,7 @@ Short Circuit</h5>
 
 	The full Council process <em class=rfc2119>may</em> be short-circuited if
 	the Team recommends a resolution
-	and potential members of a Council who are not renouncing their seat
+	and potential members of a Council from elected and appointed positions who are not renouncing their seat
 	confirm it by a vote which results in both of the following:
 	* at least 80% of them vote affirmatively to adopt this resolution
 	* none of them vote against adopting the resolution


### PR DESCRIPTION
This PR has the effect of subsetting the short-circuit vote to the elected+appointed members of the AB + TAG, which I believe is correct, as TimBL and the CEO (and other Team contacts if any) have likely already had the chance to contribute to the Team recommendation for the short-circuit.

This PR is based on discussion in #793, and generalized beyond just TimBL.

If we accept this PR then we can close #793 without any of the suggested changes therein, as this PR solves the problem that motivated #793 and does so in a more general and desirable manner.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tantek/w3process/pull/906.html" title="Last updated on Aug 9, 2024, 6:25 PM UTC (6b27763)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/906/c0e2edc...tantek:6b27763.html" title="Last updated on Aug 9, 2024, 6:25 PM UTC (6b27763)">Diff</a>