### PR TITLE
Streamline Council formation and provide safeguards

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2575,13 +2575,13 @@ Convening the Council</h5>
 	the [=W3C Council=] is considered to be <dfn>convened</dfn>
 	and can start [[#council-deliberations|deliberations]].
 
-	If a [=W3C Council=] has not yet been convened within 90 days of a Formal Objection
+	If a [=W3C Council=] has not yet been [=convened=] within 90 days of a Formal Objection
 	being [[#registering-objections|registered]],
 	the [=Chairs=] of the [=TAG=] and [=AB=] <em class=rfc2119>may</em> take independent action to ensure
 	that the [=dismissal=], [=renunciation=],
 	and [[#council-chairing|chair selection]] processes have been run.
 	If a report from the Team is not delivered within those 90 days,
-	the [=Council=] is considered convened
+	the [=Council=] is considered [=convened=]
 	upon selection of the [=W3C Council Chair|Council Chair=].
 
 <h5 id=council-deliberations>
@@ -2649,7 +2649,7 @@ Council Deliberations</h5>
 	and its [=Council Team Contact=].
 
 	<p id=45-day-update>
-	If a [=W3C Council=] is unable to come to a conclusion within 45 days of being <a href="#council-convention">convened</a>,
+	If a [=W3C Council=] is unable to come to a conclusion within 45 days of being [=convened=],
 	the [=W3C Council Chair=] <em class=rfc2119>must</em> inform the [=AC=] of this delay
 	and of the status of the discussions.
 	The [=W3C Council Chair=] <em class=rfc2119>may</em> additionally make this report <a href="#confidentiality-levels">public</a>.

--- a/index.bs
+++ b/index.bs
@@ -2581,10 +2581,9 @@ Council Deliberations</h5>
 	the [=Chairs=] of the [=TAG=] and [=AB=] <em class=rfc2119>may</em> take independent action to ensure
 	that the [=dismissal=], [=renunciation=],
 	and [[#council-chairing|chair selection]] processes have been run.
-	Past the 90 days limit,
+	If a report from the Team is not delivered within those 90 days,
 	the [=Council=] is considered convened
-	as soon as the [=W3C Council Chair=] has been selected,
-	even in the absence of a report from the Team.
+	upon selection of the [=W3C Council Chair|Council Chair=].
 
 	The Council <em class=rfc2119>may</em> conduct additional research or analysis,
 	or request additional information or interviews from anyone,

--- a/index.bs
+++ b/index.bs
@@ -2402,6 +2402,10 @@ Investigation and Mediation by the Team</h4>
 	to make sure the problem and the various viewpoints are well understood,
 	and to the extent possible,
 	to arrive at a recommended disposition.
+
+	In parallel, the Team <em class=rfc2119>should</em> start the steps necessary
+	to <a href="#council-convention">convene</a> a Council.
+
 	If the [=Team=] can resolve the issue
 	to the satisfaction of the individual that filed the [=Formal Objection=],
 	the individual withdraws the objection and the disposition process terminates.
@@ -2409,10 +2413,10 @@ Investigation and Mediation by the Team</h4>
 	Otherwise,
 	upon concluding that consensus cannot be found,
 	and no later than 90 days after the [=Formal Objection=] being registered,
-	the [=Team=] <em class=rfc2119>must</em> initiate formation of a [=W3C Council=],
-	which should be <a href="#council-convention">convened</a> within 45 days of being initiated.
-	Concurrently, it must prepare a report for the [=Council=]
-	documenting its findings and attempts to find consensus.
+	the [=Team=] <em class=rfc2119>must</em>
+	deliver to the [=Council=] a report
+	documenting its findings and attempts to find consensus,
+	and hand over the matter to the [=W3C Council=].
 
 <h4 id=council>
 W3C Council</h4>
@@ -2572,8 +2576,17 @@ Council Deliberations</h5>
 	the [=W3C Council=] is considered to be convened
 	and can start deliberations.
 
-	Having reviewed the information gathered by the [=Team=],
-	the Council <em class=rfc2119>may</em> conduct additional research or analysis,
+	If a [=W3C Council=] has not yet been convened within 90 days of a Formal Objection
+	being [[#registering-objections|registered]],
+	the [=Chairs=] of the [=TAG=] and [=AB=] <em class=rfc2119>may</em> take independent action to ensure
+	that the [=dismissal=], [=renunciation=],
+	and [[#council-chairing|chair selection]] processes have been run.
+	Past the 90 days limit,
+	the [=Council=] is considered convened
+	as soon as the [=W3C Council Chair=] has been selected,
+	even in the absence of a report from the Team.
+
+	The Council <em class=rfc2119>may</em> conduct additional research or analysis,
 	or request additional information or interviews from anyone,
 	including the Team.
 

--- a/index.bs
+++ b/index.bs
@@ -2567,14 +2567,13 @@ Council Chairing</h5>
 	if requested by the [=Council Team Contact=] or by the [=Chair=]
 	during the Council’s operation.
 
-<h5 id=council-deliberations>
-Council Deliberations</h5>
+<h5 id=council-convention>
+Convening the Council</h5>
 
-	<p id=council-convention>
 	Upon appointment of the [=W3C Council Chair=]
 	and delivery of the [=Team=]’s report,
-	the [=W3C Council=] is considered to be convened
-	and can start deliberations.
+	the [=W3C Council=] is considered to be <dfn>convened</dfn>
+	and can start [[#council-deliberations|deliberations]].
 
 	If a [=W3C Council=] has not yet been convened within 90 days of a Formal Objection
 	being [[#registering-objections|registered]],
@@ -2585,7 +2584,11 @@ Council Deliberations</h5>
 	the [=Council=] is considered convened
 	upon selection of the [=W3C Council Chair|Council Chair=].
 
-	The Council <em class=rfc2119>may</em> conduct additional research or analysis,
+<h5 id=council-deliberations>
+Council Deliberations</h5>
+
+	Once [=convened=],
+	the Council <em class=rfc2119>may</em> conduct additional research or analysis,
 	or request additional information or interviews from anyone,
 	including the Team.
 


### PR DESCRIPTION
A major source of dissatisfaction with the current Formal Objection handling process is the time it takes to initiate Councils. This brings the following improvements:
* This makes it clear that the administrative steps for forming a council are expected to happen in parallel with the Team's effort to resolve and/or document the objection, which should cut the waiting time (and matches what the Team is moving towards anyway).
* Currently convening a Council *must* start within 90 days of FO registration, and *should* be complete within an extra 45 days. not only is this long, it means there is no actual hard end date. After this change, the hard deadline is 90 days.
* Previously, nothing happened if the deadlines were exceeded. This empowers the AB and TAG chairs to complete council formation once we're past the deadlines.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/925.html" title="Last updated on Oct 22, 2024, 5:12 AM UTC (84b6df3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/925/0ed746a...frivoal:84b6df3.html" title="Last updated on Oct 22, 2024, 5:12 AM UTC (84b6df3)">Diff</a>