### PR TITLE
Require resignation from AB/TAG/BoD as a condition of service

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1118,7 +1118,14 @@ Elected Groups Participation Constraints</h5>
 			the <a href="#random">verifiable random selection procedure</a> described below
 			to choose one person for continued participation and declare the other seat(s) vacant.
 		<li>
-			An individual <em class="rfc2119">must not</em> participate on both the TAG and the AB.
+			The same individual <em class="rfc2119">must not</em> participate on any two of:
+			the TAG,
+			the AB,
+			or the [=W3C Board of Directors=].
+			An individual who is appointed or selected for AB or TAG,
+			<em class=rfc2119>must</em> either <a href=#resignation>resign</a> from any other position
+			on the other listed bodies or
+			refuse the position.
 	</ul>
 
 <h5 id="AB-TAG-elections">


### PR DESCRIPTION
This is part 1 of a solution for #921.
This expands the restriction against concurrent AB/TAG participation to include the BoD.
It does so in a bit of an awkward way,
because the Process cannot tell the BoD how to operate. It is therefore double-ended:

1. If you are appointed to any listed body, you need to resign from the AB or TAG.
2. If you are appointed to the AB or TAG, you cannot accept unless you resign from the other body.