### PR TITLE
Forbid the Team from AB/TAG service

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1119,6 +1119,11 @@ Elected Groups Participation Constraints</h5>
 			to choose one person for continued participation and declare the other seat(s) vacant.
 		<li>
 			An individual <em class="rfc2119">must not</em> participate on both the TAG and the AB.
+		<li>
+			Members of the [=Team=] <em class=rfc2119>must not</em> participate on the AB or TAG,
+			except as defined by this process.
+			In particular, the role of Team Contact is defined for both
+			[[#ABParticipation|AB]] and [[#tag-participation|TAG]].
 	</ul>
 
 <h5 id="AB-TAG-elections">


### PR DESCRIPTION
The Team already has a clearly defined role in the process. Being responsible for appointments to the TAG, for instance, would make service on the TAG a bit of a conflict. Another example is the role of the Team in Councils, for which clearer rules would be clarifying.

I believe that this was a bit of a problem in the distant past, but during my involvement with the organization,
this has never come up.
This is offered as a clarification,
not as a reaction to a particular situation.

This is part 2 of the recommendations in #921.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/w3c-process/pull/929.html" title="Last updated on Oct 8, 2024, 3:40 AM UTC (2f862fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/929/c165854...martinthomson:2f862fb.html" title="Last updated on Oct 8, 2024, 3:40 AM UTC (2f862fb)">Diff</a>