### PR TITLE
fix id attr typo lifecyle->lifecycle

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1705,7 +1705,7 @@ Team Representative in an Interest Group</h5>
 	When the participation requirements exceed <a href="#ig-mail-only">Interest Group mailing list subscription</a>,
 	an individual is a <dfn export>Team representative in an Interest Group</dfn> when so designated by W3C management.
 
-<h2 id=group-lifecyle>
+<h2 id=group-lifecycle>
 Lifecycle of Chartered Groups</h2>
 
 	W3C creates [=charters=] for [=chartered groups=] based on interest from the [=Members=] and [=Team=].


### PR DESCRIPTION
Match id attribute with proper spelling in visible h2


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tantek/w3process/pull/939.html" title="Last updated on Oct 31, 2024, 5:25 PM UTC (a056129)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/939/ff5a050...tantek:a056129.html" title="Last updated on Oct 31, 2024, 5:25 PM UTC (a056129)">Diff</a>