### PR TITLE
Be more specific about when the council composition is locked down

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2439,6 +2439,10 @@ Council Composition</h5>
 	Membership of each [=Council=] instance is fixed at formation,
 	and is not changed by any [=AB=] or [=TAG=] elections
 	occurring before that Council has reached a conclusion.
+	Specifically, the list of potential [=Council=] members evolves
+	as terms start or end
+	so long as [=dismissal=] has not concluded,
+	but is fixed thereafter.
 	However, if participation in a [=Council=] falls so low as to hinder effective and balanced deliberations,
 	the [=W3C Council Chair=] <em class="rfc2119">should</em> dissolve the [=Council=]
 	and call for a new one to be convened.

--- a/index.bs
+++ b/index.bs
@@ -2436,15 +2436,15 @@ Council Composition</h5>
 	Participation in a [=W3C Council=] <em class=rfc2119>must not</em> require attendance of [=face-to-face meetings=].
 
 	A distinct instance of the [=W3C Council=] is convened for each decision being appealed or objected to.
-	Membership of each [=Council=] instance is fixed at formation,
+	The list of potential [=Council=] members evolves
+	as [=AB=] and [=TAG=] terms start and end
+	until [=dismissal=] and [=renunciation=] are concluded,
+	at which point all remaining potential [=Council=] members become full members.
+	Thereafter, the membership of the [=Council=] is fixed,
 	and is not changed by any [=AB=] or [=TAG=] elections
-	occurring before that Council has reached a conclusion.
-	Specifically, the list of potential [=Council=] members evolves
-	as terms start or end
-	so long as [=dismissal=] has not concluded,
-	but is fixed thereafter.
-	However, if participation in a [=Council=] falls so low as to hinder effective and balanced deliberations,
-	the [=W3C Council Chair=] <em class="rfc2119">should</em> dissolve the [=Council=]
+	that occur before that Council has reached a conclusion.
+	However, if the number of active members in a [=Council=] falls so low as to hinder effective and balanced deliberations,
+	the [=Council Chair=] <em class="rfc2119">should</em> dissolve the [=Council=]
 	and call for a new one to be convened.
 
 	A [=Team=] member is assigned


### PR DESCRIPTION
This drafts option 1 of #926


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/955.html" title="Last updated on Jan 8, 2025, 6:17 AM UTC (28d0f63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/955/2442b54...frivoal:28d0f63.html" title="Last updated on Jan 8, 2025, 6:17 AM UTC (28d0f63)">Diff</a>