### PR TITLE
Decrease emphasis on FO to charter rejection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1741,7 +1741,7 @@ Initiating Charter Refinement</h3>
 	that the [=Team=] initiate [=charter refinement=].
 	The Team <em class=rfc2119>may</em> deny such a request
 	if it thinks the proposal is insufficiently mature or does not align with W3C's scope and mission.
-	This rejection is a [=Team Decision=] which can be <a href="#registering-objections">Formally Objected to</a>.
+	This rejection is a [=Team Decision=].
 
 <h3 id="charter-development" oldids="WGCharterDevelopment">
 Charter Refinement</h3>


### PR DESCRIPTION
Team Decisions can be objected to, so it is not necessary to emphasize that fact. Too much attention to that point could encourage litigiousness, which would be counter productive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/964.html" title="Last updated on Dec 19, 2024, 11:40 AM UTC (bdcb2f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/964/f06e579...frivoal:bdcb2f4.html" title="Last updated on Dec 19, 2024, 11:40 AM UTC (bdcb2f4)">Diff</a>