### PR TITLE
Add explicit Team verification of charter refinement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1775,7 +1775,8 @@ Charter Refinement</h3>
 		(though only W3C [=Members=] and the [=Team=] can participate in any formal [[#Votes|vote]]).
 
 	The [=charter refinement=] phase concludes when there is either:
-	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=].
+	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=],
+		subject to [=Team=] verification that the expectations of [=charter refinement=] are fulfilled.
 	* A [=chair decision=] by the [=Chartering Facilitator=] to abandon the proposal.
 
 	Any [=Formal Objection=] filed during the  [=charter refinement=] phase--


### PR DESCRIPTION
See https://github.com/w3c/process/issues/971


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/973.html" title="Last updated on Jan 8, 2025, 4:25 PM UTC (457157d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/973/808f023...frivoal:457157d.html" title="Last updated on Jan 8, 2025, 4:25 PM UTC (457157d)">Diff</a>