### PR TITLE
Require decision by both the facilitator and team to abandon chartering

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1775,7 +1775,7 @@ Charter Refinement</h3>
 	The [=charter refinement=] phase concludes when there is either:
 	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=],
 		subject to [=Team=] verification that the expectations of [=charter refinement=] are fulfilled.
-	* A [=chair decision=] by the [=Chartering Facilitator=] to abandon the proposal.
+	* A [=chair decision=] by the [=Chartering Facilitator=], confirmed by a [=Team Decision=], to abandon the proposal.
 
 	Any [=Formal Objection=] filed during the  [=charter refinement=] phase--
 	other than an objection to the choice of [=Chartering Facilitator=]

--- a/index.bs
+++ b/index.bs
@@ -1772,7 +1772,7 @@ Charter Refinement</h3>
 	* Decisions are made as [=group decisions=], where the group is made up of all individuals participating in this process,
 		(though only W3C [=Members=] and the [=Team=] can participate in any formal [[#Votes|vote]]).
 
-	The [=charter refinement=] phase concludes when there is either:
+	The [=charter refinement=] phase concludes when there is either of the following:
 	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=],
 		subject to [=Team=] verification that the expectations of [=charter refinement=] are fulfilled.
 	* A [=chair decision=] by the [=Chartering Facilitator=], confirmed by a [=Team Decision=], to abandon the proposal.


### PR DESCRIPTION
See #982

In terms of phrasing, I opted to keep the idea of a decision by the facilitator, confirmed by a decision of the team, rather than something like a team decision to accept a proposal by facilitator, because hooking into the notion of Chair Decision gives us an explicit statement that this is something they do in the own judgement, not based on the consensus of the group. And given that a key reason for giving up on a charter could be that the relevant community is proving incapable of consensus (which could possibly even extend to the question of whether to give up), that seems relevant.