### PR TITLE
Use appeal vote as escalation path for rejecting charter refinement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1751,7 +1751,13 @@ Initiating Charter Refinement</h3>
 	that the [=Team=] initiate [=charter refinement=].
 	The Team <em class=rfc2119>may</em> deny such a request
 	if it thinks the proposal is insufficiently mature or does not align with W3C's scope and mission.
-	This rejection is a [=Team Decision=].
+	This rejection is a [=Team Decision=],
+	and can be appealed only if 5 or more [=Members=],
+	through their [=Advisory Committee representative=],
+	formally object to the decision within X weeks of the decision being announced.
+	In this case the [=Team=] <em class=rfc2119>must</em> start an [=appeal vote=]
+	on whether to overturn the [=Team Decision=].
+	(No action is required to be taken when fewer than 5 members object.)
 
 <h3 id="charter-development" oldids="WGCharterDevelopment">
 Charter Refinement</h3>
@@ -2873,7 +2879,7 @@ Advisory Committee Votes</h3>
 
 	The [=Advisory Committee=] votes in <a href="#AB-TAG-elections">elections for seats on the TAG or Advisory Board</a>,
 	and in the event of an [=Advisory Committee Appeal=]
-	achieving the required support to trigger an appeal vote.
+	achieving the required support to trigger an [=appeal vote=].
 	Whenever the [=Advisory Committee=] votes,
 	each Member or group of [=related Members=] has one vote.
 
@@ -2921,7 +2927,7 @@ Appeal by Advisory Committee Representatives</h3>
 	The archive of these statements <em class="rfc2119">must</em> be [=member-only=].
 	If, within <span class="time-interval">one week</span> of the Team's announcement,
 	5% or more of the [=Advisory Committee=] support the appeal request,
-	the Team <em class="rfc2119">must</em> organize an appeal vote
+	the Team <em class="rfc2119">must</em> organize an <dfn>appeal vote</dfn>
 	asking the [=Advisory Committee=]
 	“Do you approve of the Decision?”
 	together with links to the decision and the appeal support.


### PR DESCRIPTION
This takes inspiration from parts of a proposal by @ianbjacobs.

Invoking W3C Councils is a time consuming and expensive endeavour, so we should look at cheaper ways to address escalation against the decision not to start charter refinement.

Since charter refinement is unlikely to be successful if not enough members are interested, dismissing the escalation when it is supported by fewer than 5 members seems like a cost effective filter. When there are 5 or more, an appeals vote is a more cost effective way to decide the question than an Council, and since this is only about the start of charter refinement, deep discussions, such as those that a Council would enable, don't seem necessary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/991.html" title="Last updated on Feb 25, 2025, 10:31 AM UTC (04754ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/991/eb8f470...frivoal:04754ba.html" title="Last updated on Feb 25, 2025, 10:31 AM UTC (04754ba)">Diff</a>