### PR TITLE
Enable members to push for resuming an abandoned charter refinement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1777,12 +1777,18 @@ Charter Refinement</h3>
 		subject to [=Team=] verification that the expectations of [=charter refinement=] are fulfilled.
 	* A [=chair decision=] by the [=Chartering Facilitator=], confirmed by a [=Team Decision=], to abandon the proposal.
 
-	Any [=Formal Objection=] filed during the  [=charter refinement=] phase--
-	other than an objection to the choice of [=Chartering Facilitator=]
-	or to a decision to abandon the proposal--
-	is not considered [[#registering-objections|registered]]
-	until the close of the [=Advisory Committee Review=] of the charter,
-	and is registered against that [=W3C Decision=].
+	[=Formal Objections=] filed during the [=charter refinement=] phase
+	are specially handled:
+	* Objections to the choice of [=Chartering Facilitator=] are processed normally (See [[#addressing-fo]]).
+	* Objections to abandoning the proposal can be appealed only if 5 or more Members,
+		through their [=Advisory Committee representative=],
+		formally object to the decision within X weeks of the decision being announced.
+		In this case, the [=Team=] must either resume charter refinement
+		or refer the matter to the [=Council=].
+		(No action is required to be taken when fewer than 5 members object.)
+	* All other objections are considered registered
+		at the close of the [=Advisory Committee Review=] of the charter,
+		and are registered against that [=W3C Decision=].
 
 	Note: This enables all [=Formal Objections=] on the same proposed [=charter=] to be handled together.
 


### PR DESCRIPTION
This takes inspiration from parts of a proposal by @ianbjacobs.

The Council is a powerful but expensive way to resolve disagreements.

If a very limited number of members oppose abandoning a charter-in-progress, the charter would fail AC Review anyway, and abandoning was the right decision.

If 5 or more Members insist that abandoning the charter refinement was the wrong decision, that is a strong indication that there is enough interest and that the decision was premature. The charter may not quite be ready for AC Review yet, but enough people have hope that it can become ready that resuming discussions is the appropriate default reaction. The facilitator remains the arbiter of how much more effort to spend on the attempt, and of when to send the draft to the AC for review.

Nevertheless, the Team may judge that despite pronounced member interest, the situation is inextricable, and that no charter can be produced that could be worth sending to the AC for review. In that case, the Team can refer the case to the Council, hoping to gain approval for the decision to abandon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/992.html" title="Last updated on Feb 25, 2025, 10:49 AM UTC (875625e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/992/eb8f470...frivoal:875625e.html" title="Last updated on Feb 25, 2025, 10:49 AM UTC (875625e)">Diff</a>