### PR TITLE
Allow Team to step in when consensus cannot be found during Charter Refinement.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1791,8 +1791,9 @@ Charter Refinement</h3>
 	* [=Wide review=] of the [=charter draft=] is initiated and completed.
 	* All issues filed against the [=charter draft=] must be [=formally addressed=],
 		and their resolutions tracked in a disposition of comments.
-	* Decisions are made as [=group decisions=], where the group is made up of all individuals participating in this process,
-		(though only W3C [=Members=] and the [=Team=] can participate in any formal [[#Votes|vote]]).
+	* Decisions are made as [=group decisions=], where the group is made up of all individuals participating in this process.
+		If the [=Chartering Facilitator=] determines that consensus cannot be found,
+		in lieu of calling a [[#Votes|Vote]], they may ask the Team to make a [=Team Decision=].
 
 	The [=charter refinement=] phase concludes when there is either of the following:
 	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=],


### PR DESCRIPTION
Ian's proposal describes

> The Team must seek community [consensus](https://www.w3.org/policies/process/#consensus-building) among those participating in the refinement process, and must [formally address all issues](https://www.w3.org/policies/process/#formal-address) (raised via the advertised mechanism). The Team is responsible for managing situations where the W3C community cannot achieve consensus and supports multiple related (and competing) charters.

This proposal preserves the current mode of the Chartering Facilitator, specifically, acting as the chair in determining the consensus of the community, but allows them to ask the Team to step in when consensus cannot be found.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fantasai/w3process/pull/997.html" title="Last updated on Mar 11, 2025, 4:24 PM UTC (a286c2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/997/0d6e9c4...fantasai:a286c2f.html" title="Last updated on Mar 11, 2025, 4:24 PM UTC (a286c2f)">Diff</a>