### PR TITLE
Drop unnecessary remarks about optional communication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1739,8 +1739,6 @@ Initiating Charter Refinement</h3>
 	Prior to the formal [=charter refinement|refinement=] phase,
 	the [=Team=] engages with those various parties
 	to help prepare [=charters=] for broader audiences.
-	The [=Team=] <em class=rfc2119>may</em> send notice to the [=AC=]
-	when starting development of a new charter prior to the [=charter refinement=] phase.
 
 	Formal [=charter refinement=] (see below) is initiated
 	by the [=Team=] sending a [=charter review notice=]


### PR DESCRIPTION
This sentence was kept because the notion of an advance notice was preexisting, and we wanted to distinguish the pre-existing informal heads up message from the official message starting the phase.

However, it may be more confusing that helpful.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/998.html" title="Last updated on Mar 12, 2025, 4:30 AM UTC (d53ba5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/998/0d6e9c4...frivoal:d53ba5e.html" title="Last updated on Mar 12, 2025, 4:30 AM UTC (d53ba5e)">Diff</a>