### PR TITLE
Drop unnecessary detail

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1749,7 +1749,6 @@ Initiating Charter Refinement</h3>
 	and, in the case of rechartering, to the affected [=Group=].
 
 	This <dfn>charter review notice</dfn> must include:
-	* A short summary of the proposal.
 	* The location of the <dfn>charter draft</dfn>, which must be public.
 	* How to participate in the discussion of this [=charter draft=] and where to file issues.
 	* The expected duration of the [=charter refinement=] phase,


### PR DESCRIPTION
Every email explains what the email is about. We can make the Process a tiny be shorter by not restating the obvious.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/999.html" title="Last updated on Mar 12, 2025, 4:32 AM UTC (9dabf68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/999/0d6e9c4...frivoal:9dabf68.html" title="Last updated on Mar 12, 2025, 4:32 AM UTC (9dabf68)">Diff</a>