### PR TITLE
Move details of how the Team evaluates charters to the guide

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1763,7 +1763,8 @@ Initiating Charter Refinement</h3>
 	An [=Advisory Committee representative=] <em class=rfc2119>may</em> formally request
 	that the [=Team=] initiate [=charter refinement=].
 	The Team <em class=rfc2119>may</em> deny such a request
-	if it thinks the proposal is insufficiently mature or does not align with W3C's scope and mission,
+	if it thinks the proposal does not meet the charter assessment criteria
+	described in the Guide,
 	and <em class=rfc2119>must</em> reply with its rationale.
 	This rejection is a [=Team Decision=],
 	and can be appealed only by 5 or more [=Members=],

--- a/index.bs
+++ b/index.bs
@@ -1764,7 +1764,7 @@ Initiating Charter Refinement</h3>
 	that the [=Team=] initiate [=charter refinement=].
 	The Team <em class=rfc2119>may</em> deny such a request
 	if it thinks the proposal does not meet the charter assessment criteria
-	described in the Guide,
+	described in the Guide (see [[CHARTER inline]]),
 	and <em class=rfc2119>must</em> reply with its rationale.
 	This rejection is a [=Team Decision=],
 	and can be appealed only by 5 or more [=Members=],

--- a/index.bs
+++ b/index.bs
@@ -1763,7 +1763,9 @@ Initiating Charter Refinement</h3>
 	An [=Advisory Committee representative=] <em class=rfc2119>may</em> formally request
 	that the [=Team=] initiate [=charter refinement=].
 	The Team <em class=rfc2119>may</em> deny such a request
-	if it thinks the proposal does not meet the charter assessment criteria
+        if it thinks the proposal is insufficiently mature,
+        does not align with W3C's scope and mission,
+	or otherwise does not meet the charter assessment criteria
 	described in the Guide (see [[CHARTER inline]]),
 	and <em class=rfc2119>must</em> reply with its rationale.
 	This rejection is a [=Team Decision=],


### PR DESCRIPTION
This is similar to how we move the Team's evaluation criteria for Member submissions to the Guide.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1000.html" title="Last updated on Apr 23, 2025, 3:13 PM UTC (7c152b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1000/cf784bd...frivoal:7c152b3.html" title="Last updated on Apr 23, 2025, 3:13 PM UTC (7c152b3)">Diff</a>