### PR TITLE
Drop wide review of charters from the Process

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1788,7 +1788,6 @@ Charter Refinement</h3>
 	Note: The [=Chartering Facilitator=] is not necessarily the [=Chair=] of the [=chartered group|group=] being chartered.
 
 	During [=charter refinement=]:
-	* [=Wide review=] of the [=charter draft=] is initiated and completed.
 	* All issues filed against the [=charter draft=] must be [=formally addressed=],
 		and their resolutions tracked in a disposition of comments.
 	* Decisions are made as [=group decisions=], where the group is made up of all individuals participating in this process,


### PR DESCRIPTION
It's been suggested that this could be left to the guide. This PR implements that possible change.

Personally, I'm not convinced, and I think it is worth hard-coding this expectation into the Process, but I'm offering the PR to anchor discussion of that aspect.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1001.html" title="Last updated on Mar 26, 2025, 2:38 AM UTC (5d41c27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1001/0d6e9c4...frivoal:5d41c27.html" title="Last updated on Mar 26, 2025, 2:38 AM UTC (5d41c27)">Diff</a>