### PR TITLE
Facilitator not explicitly chair

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1785,6 +1785,9 @@ Charter Refinement</h3>
 	who is chosen (and <em class=rfc2119>may</em> be replaced) by the [=Team=]--
 	is responsible for seeking community [=consensus=] among those participating in the refinement process
 	and making decisions reflecting that [=consensus=].
+	In cases where [=consensus=] cannot be found,
+	the [=Chartering Facilitator=] <em class=rfc2119>may</em> ask the [=Team=] to make a [=Team Decision=],
+	and <em class=rfc2119>must</em> document the rationale for the decision.
 
 	Note: The [=Chartering Facilitator=] is not necessarily the [=Chair=] of the [=chartered group|group=] being chartered.
 

--- a/index.bs
+++ b/index.bs
@@ -1783,8 +1783,8 @@ Charter Refinement</h3>
 	with the goal of achieving [=consensus=] on the proposal.
 	The <dfn>Chartering Facilitator</dfn>--
 	who is chosen (and <em class=rfc2119>may</em> be replaced) by the [=Team=]--
-	is responsible for seeking community consensus among those participating in the refinement process
-	and making decisions reflecting that consensus.
+	is responsible for seeking community [=consensus=] among those participating in the refinement process
+	and making decisions reflecting that [=consensus=].
 
 	Note: The [=Chartering Facilitator=] is not necessarily the [=Chair=] of the [=chartered group|group=] being chartered.
 
@@ -1794,10 +1794,11 @@ Charter Refinement</h3>
 		and their resolutions tracked in a disposition of comments
 		highlighting any issues not resolved by consensus.
 
-	The [=charter refinement=] phase concludes when there is either of the following:
-	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=],
-		subject to [=Team=] verification that the expectations of [=charter refinement=] are fulfilled.
-	* A [=chair decision=] by the [=Chartering Facilitator=], confirmed by a [=Team Decision=], to abandon the proposal.
+	The [=charter refinement=] phase concludes
+	when there is a [=Team Decision=]
+	(informed by the work of the [=Chartering Facilitator=])
+	either to initiate [=AC Review=] of the [=charter draft=],
+	or to abandon the proposal.
 
 	[=Formal Objections=] filed during the [=charter refinement=] phase
 	are specially handled:

--- a/index.bs
+++ b/index.bs
@@ -1783,8 +1783,8 @@ Charter Refinement</h3>
 	with the goal of achieving [=consensus=] on the proposal.
 	The <dfn>Chartering Facilitator</dfn>--
 	who is chosen (and <em class=rfc2119>may</em> be replaced) by the [=Team=]--
-	acts as [=Chair=] for the [=charter refinement=] process,
-	and is responsible for seeking community consensus among those participating in the refinement process.
+	is responsible for seeking community consensus among those participating in the refinement process
+	and making decisions reflecting that consensus.
 
 	Note: The [=Chartering Facilitator=] is not necessarily the [=Chair=] of the [=chartered group|group=] being chartered.
 
@@ -1793,8 +1793,6 @@ Charter Refinement</h3>
 	* All issues filed against the [=charter draft=] must be [=formally addressed=],
 		and their resolutions tracked in a disposition of comments
 		highlighting any issues not resolved by consensus.
-	* Decisions are made as [=group decisions=], where the group is made up of all individuals participating in this process,
-		(though only W3C [=Members=] and the [=Team=] can participate in any formal [[#Votes|vote]]).
 
 	The [=charter refinement=] phase concludes when there is either of the following:
 	* A [=group decision=] or [=Team Decision=] to initiate [=AC Review=] of the [=charter draft=],


### PR DESCRIPTION
This is a suggestion by @ianbjacobs to work around the lack of a clearly defined group.

----

I think the explicit reference in the opening sentence to decisions (plural) being made based on that consensus is helpful.

This does lack clarity about what happens when there isn't consensus, though we may be able to combine it with https://github.com/w3c/process/pull/997 to deal with that case…

I am less certain about removing the the different types of decisions a that can conclude the phase. This is certainly simpler, but there distinction in the original text were deliberate.

Still, offering this PR for discussion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1002.html" title="Last updated on Mar 26, 2025, 4:02 PM UTC (240fb3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1002/cf784bd...frivoal:240fb3a.html" title="Last updated on Mar 26, 2025, 4:02 PM UTC (240fb3a)">Diff</a>