### PR TITLE
Reframe the various kinds of Objection handling for charter refinement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1803,16 +1803,17 @@ Charter Refinement</h3>
 
 	[=Formal Objections=] filed during the [=charter refinement=] phase
 	are specially handled:
-	* Objections to the choice of [=Chartering Facilitator=] are processed normally (See [[#addressing-fo]]).
 	* Objections to abandoning the proposal can be appealed only if 5 or more Members,
 		through their [=Advisory Committee representative=],
 		formally object to the decision within 8 weeks of the decision being announced.
 		In this case, the [=Team=] must either resume charter refinement
 		or refer the matter to the [=Council=].
 		(No action is required to be taken when fewer than 5 members object.)
-	* All other objections are considered registered
-		at the close of the [=Advisory Committee Review=] of the charter,
+	* Objections to decisions pertaining to the content of the charter,
+		as well as objections to initiating the [=AC Review=],
+		are considered registered at the close of the [=Advisory Committee Review=] of the charter,
 		and are registered against that [=W3C Decision=].
+	* Any other objections are processed normally (See [[#addressing-fo]]).
 
 	Note: This enables all [=Formal Objections=] on the same proposed [=charter=] to be handled together.
 


### PR DESCRIPTION
In the original text, the point about objections to a person's assignment was not intended to highlight, or even introduce, the possibility of objecting to a person's assignment in the role of facilitator.

That possibility was taken as pre-existing consequence of how the Process works, and how all sorts of decisions can be objected to (even if that's not always the smoothest path to resolving the underlying issue).

The goal was to say that **if** such an objection happens, then unlike the objections to the content of the charter, it doesn't make sense to delay processing to the end of the AC Review and to group it with other objections to the charter.

The unfortunate side effect of that phrasing was that it drew attention to the possibility of making such an objection in the first place.

This PR is an attempt at reversing the framing, so that the emphasis is on the grouping / delaying of FOs to the charter itself instead of that clause falling under a catch "all other objections", since that really is the focus of the special case rule, and to then use a catch all for stating that other cases are handled as usual, which lets us avoid drawing unwarranted attention to any specific "other" type of FO.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1005.html" title="Last updated on Mar 26, 2025, 4:49 AM UTC (b37bd23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1005/c577441...frivoal:b37bd23.html" title="Last updated on Mar 26, 2025, 4:49 AM UTC (b37bd23)">Diff</a>