### PR TITLE
Make cross reference more obvious

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3602,7 +3602,8 @@ Maturity Stages on the Recommendation Track</h4>
 
 			<p id="expandable-rec">
 			After its initial publication,
-			a [=W3C Recommendation=] <em class=rfc2119>may</em> be [[#revising-rec|revised]]
+			a [=W3C Recommendation=] <em class=rfc2119>may</em> be revised
+			(in accordance with [[#revising-rec|]])
 			to address [=editorial change|editorial=] or [=substantive change|substantive=] issues
 			that are discovered later.
 			However, <a href=#class-4>new features</a> can only be added


### PR DESCRIPTION
The referenced section has a bunch of rules, it would not be good if they were overlooked.

See https://github.com/w3c/process/issues/1008