### PR TITLE
Reworking TAG/AB disciplinary removal

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1329,8 +1329,12 @@ Removing AB or TAG members</h5>
 	Individual participants of the [=Advisory Board=] or the [=Technical Architecture Group=]
 	can be <dfn export lt="remove|removal">removed</dfn> from those groups
 	if they are found by their peers
-	to be grossly neglecting their duties,
-	or to be acting in a way that seriously hampers the group's ability to function.
+	to be grossly neglecting their duties
+	or acting in a way that seriously hampers the group's ability to function;
+	or if they are violating policies or other standards of behavior
+	(such as applicable laws or the <a href="https://www.w3.org/policies/code-of-conduct/#Reporting">Code of Conduct</a>)
+	in a way that significantly impacts the safety or integrity
+	of W3C or its community.
 
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold an <i>in camera</i> hearing
 	on the potential [=removal=] of a participant

--- a/index.bs
+++ b/index.bs
@@ -472,7 +472,7 @@ Expectations and Discipline</h5>
 
 	The [=CEO=] <em class="rfc2119">may</em> take disciplinary action,
 	including suspending or removing for cause
-	a participant in any group (including the [=AB=] and [=TAG=])
+	any participant from any group (except [=elected groups=])
 	if serious and/or repeated violations,
 	such as failure to meet the requirements on individual behavior of
 	(a) this process
@@ -481,6 +481,7 @@ Expectations and Discipline</h5>
 	(c) applicable laws,
 	occur.
 	Refer to the <a href="https://www.w3.org/guide/process/suspension">Guidelines to suspend or remove participants from groups</a>.
+	See [[#AB-TAG-removal]] for removal from an [=elected group=].
 
 <h5 id="coi">
 Conflict of Interest Policy</h5>
@@ -1351,17 +1352,26 @@ Removing AB or TAG members</h5>
 
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold an <i>in camera</i> hearing
 	on the potential [=removal=] of a participant
-	if requested by at least three of the participants in the group.
+	if requested by at least three of the participants in the group
+	or if requested by a [=Team decision=]
+	(which must provide rationale for such [[#discipline|disciplinary action]]).
 	After giving the individual in question
 	an opportunity to defend themselves,
 	a vote on the proposed [=removal=] is held by secret ballot.
 	If at least three quarters of the participants in the group,
-	excluding the individual who is the subject of such vote,
+	excluding the individual who is the subject of such vote--
+	or two thirds, in the case of a [=Team=] request--
 	then vote in favor of the proposal,
 	the individual's seat on [=AB=] or [=TAG=] is [=vacated=] immediately.
 	The group must notify the [=AC=] of such a [=removal=] within one week.
 
 	Note: Removal from the [=AB=] or [=TAG=] does not imply removal from a convened [=Council=].
+
+	In extraordinary cases where a participant is endangering W3C or members of its community
+	and the group refuses or is unable to act,
+	the [=Board of Directors=] <em class=rfc2119>may</em>
+	remove a participant of the [=AB=] or [=TAG=]
+	by a two-thirds supermajority vote of the Directors.
 
 <h5 id="AB-TAG-vacated">
 Elected Groups Vacated Seats</h5>

--- a/index.bs
+++ b/index.bs
@@ -1332,12 +1332,12 @@ Removing AB or TAG members</h5>
 	to be grossly neglecting their duties,
 	or to be acting in a way that seriously hampers the group's ability to function.
 
-	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold a hearing
+	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold an <i>in camera</i> hearing
 	on the potential [=removal=] of a participant
 	if requested by at least three of the participants in the group.
 	After giving the individual in question
 	an opportunity to defend themselves,
-	a vote on the proposed [=removal=] is held.
+	a vote on the proposed [=removal=] is held by secret ballot.
 	If at least three quarters of the participants in the group,
 	excluding the individual who is the subject of such vote,
 	then vote in favor of the proposal,

--- a/index.bs
+++ b/index.bs
@@ -1346,6 +1346,9 @@ Removing AB or TAG members</h5>
 	in a way that significantly impacts the safety or integrity
 	of W3C or its community.
 
+	Removal <em class=rfc2119>should</em> be a last resort,
+	after reasonable attempts at remediation have failed.
+
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold an <i>in camera</i> hearing
 	on the potential [=removal=] of a participant
 	if requested by at least three of the participants in the group.

--- a/index.bs
+++ b/index.bs
@@ -460,6 +460,16 @@ Expectations and Discipline</h5>
 	“Disclosure”
 	in the W3C Patent Policy [[!PATENT-POLICY]].
 
+	A [=Chair=] <em class="rfc2119">may</em> protect their group
+	by temporarily suspending any individual
+	from any meeting or discussion under their jurisdiction
+	for causing sustained disruption of the group's discussions,
+	threatening the safety of any individual,
+	or blatantly violating other established rules.
+	The [=Team=] <em class="rfc2119">should</em> support the [=Chair decision|Chair's decision=],
+	but <em class="rfc2119">may</em> overturn such a suspension
+	if they [=Team decision|decide=] it was not (or is no longer) appropriate.
+
 	The [=CEO=] <em class="rfc2119">may</em> take disciplinary action,
 	including suspending or removing for cause
 	a participant in any group (including the [=AB=] and [=TAG=])


### PR DESCRIPTION
This pull request comprises several pieces (represented as [individual commits](https://github.com/w3c/process/pull/1036/commits)):

1. Clarifies that the AB/TAG removal procedures can be used for Code of Conduct violations. This was not clear in the original drafting, and I believe that to be a drafting error on the part of the Process CG.
2. Clarifies that the AB/TAG _should_ attempt to remediate problems before initiating removal; this isn't intended to be the first resort for problems.
3. Clarifies that the hearing and vote to remove are private.
3. Gives the Chair of a group the power to immediately and temporarily suspend a participant from a discussion or meeting for emergencies. The Team can overturn this. (Suspension is handled right now through a Team policy delegating from the CEO's powers, but if we're excluding CEO removal from the AB/TAG, then we need to make this explicit in the Process so that it also applies to the AB/TAG.)
4. A first attempt at drafting a switch from CEO removal to AB/TAG removal. It gives the Team the ability to request removal--and reduces the vote threshold in these cases--and it also adds the Board of Directors as a secondary mechanism for when the AB/TAG refuses to act on a problem.

This is an attempt to follow up on the F2F's AB+CEO discussions around #882 in which several points were brought up amidst a discussion on whether one mechanism or both should be kept:
* Making sure that Code of Conduct violations could be addressed.
* Making sure that alternate routes were possible for removal if a group was too cliquey to remove one of its members.
* Nonetheless preventing abuse of the removal powers.

Note: This PR is posted for discussion, it is not representing an AB consensus position (which has yet to develop).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fantasai/w3process/pull/1036.html" title="Last updated on May 14, 2025, 4:01 AM UTC (18cfc0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1036/92fd041...fantasai:18cfc0c.html" title="Last updated on May 14, 2025, 4:01 AM UTC (18cfc0c)">Diff</a>