### PR TITLE
Tweaks to how charter refinement concludes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1841,7 +1841,7 @@ Charter Refinement</h3>
 	with no announced decision
 	is considered a de-facto [=Team decision=] to abandon the proposal.
 	The [=Team=] <em class=rfc2119>may</em> revise such a decision
-	by announcing an alternative one.
+	by announcing an alternative decision.
 
 	[=Formal Objections=] filed during the [=charter refinement=] phase
 	are specially handled:

--- a/index.bs
+++ b/index.bs
@@ -1824,18 +1824,24 @@ Charter Refinement</h3>
 		and their resolutions tracked in a disposition of comments
 		highlighting any issues not resolved by consensus.
 
-	The [=charter refinement=] phase concludes
-	when there is a [=Team Decision=]
+	Before the end of the announced duration
+	for the [=charter refinement=] phase,
+	the [=Team=]
 	(informed by the work of the [=Chartering Facilitator=])
-	to either complete charter refinement by initiating [=AC Review=] of the [=charter draft=],
-	or abandon the proposal.
+	<em class=rfc2119>must</em> [=Team Decision|decide=] whether to:
+	* complete charter refinement by initiating [=AC Review=] of the [=charter draft=], or
+	* abandon the proposal, or
+	* extend the charter refinement period.
 
-	The [=Team=] <em class=rfc2119>may</em> [=Team Decision|decide=]
-	to extend the charter refinement period
-	by sending an announcement with the same visibility as the initial [=charter review notice=].
+	The [=Team=] <em class=rfc2119>must</em> announce its [=Team Decision|decision=]
+	with the same visibility as the initial [=charter review notice=],
+	and <em class=rfc2119>must</em> include a rationale
+	if the decision is not to start the [=AC Review=].
 	Reaching the end of the announced period (including any announced extension)
-	with neither a decision to initiate [=AC Review=] nor an announcement of extension
+	with no announced decision
 	is considered a de-facto [=Team decision=] to abandon the proposal.
+	The [=Team=] <em class=rfc2119>may</em> revise such a decision
+	by announcing an alternative one.
 
 	[=Formal Objections=] filed during the [=charter refinement=] phase
 	are specially handled:

--- a/index.bs
+++ b/index.bs
@@ -1828,10 +1828,10 @@ Charter Refinement</h3>
 	for the [=charter refinement=] phase,
 	the [=Team=]
 	(informed by the work of the [=Chartering Facilitator=])
-	<em class=rfc2119>must</em> [=Team Decision|decide=] whether to:
-	* complete charter refinement by initiating [=AC Review=] of the [=charter draft=], or
-	* abandon the proposal, or
-	* extend the charter refinement period.
+	<em class=rfc2119>must</em> [=Team Decision|decide=] which of the following to do:
+	* Complete charter refinement by initiating [=AC Review=] of the [=charter draft=].
+	* Abandon the proposal.
+	* Extend the charter refinement period.
 
 	The [=Team=] <em class=rfc2119>must</em> announce its [=Team Decision|decision=]
 	with the same visibility as the initial [=charter review notice=],

--- a/index.bs
+++ b/index.bs
@@ -1836,7 +1836,7 @@ Charter Refinement</h3>
 	The [=Team=] <em class=rfc2119>must</em> announce its [=Team Decision|decision=]
 	with the same visibility as the initial [=charter review notice=],
 	and <em class=rfc2119>must</em> include a rationale
-	if the decision is not to start the [=AC Review=].
+	if they are not initiating [=AC Review=].
 	Reaching the end of the announced period (including any announced extension)
 	with no announced decision
 	is considered a de-facto [=Team decision=] to abandon the proposal.


### PR DESCRIPTION
Based on feedback recently received.

This keeps things largely as they were, but reworks the text to be more explicit about a few things:
* The Team is actually supposed to make a decision at the end of the refinement phase; de-facto abandonment is a way to handle accidentally forgetting to do so, not a valid deliberate choice
* The Team has to announce (and give rationale) for its decisions
* If the Team (accidentally) abandons a refinement by letting it expire, they can still issue a (different) decision when they notice, without having to start a whole new refinement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1037.html" title="Last updated on May 13, 2025, 12:31 AM UTC (d0cbbc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1037/92fd041...frivoal:d0cbbc4.html" title="Last updated on May 13, 2025, 12:31 AM UTC (d0cbbc4)">Diff</a>