### PR TITLE
Clarify council text in case of multiple objections to a single decision

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2665,7 +2665,7 @@ Council Deliberations</h5>
 	even if it agrees with some of the arguments of a [=Formal Objection=].
 
 	<p id=fo-mitigations>
-	When [=overturning=] an decision,
+	When [=overturning=] a decision,
 	it <em class=rfc2199>should</em> recommend a way forward.
 	If the overturned decision has already had consequences
 	(e.g., if the objection concerns material already in a published document)

--- a/index.bs
+++ b/index.bs
@@ -2662,7 +2662,7 @@ Council Deliberations</h5>
 	the [=W3C Council=] decides whether to
 	<dfn>confirm</dfn> or <dfn>overturn</dfn> the decision being objected to.
 	The [=W3C Council=] <em class=rfc2119>may</em> [=confirm=] the decision
-	even if it agrees with some of the arguments of a [=Formal Objection=].
+	even if it agrees with some of the arguments made as part of a [=Formal Objection=].
 
 	<p id=fo-mitigations>
 	When [=overturning=] a decision,

--- a/index.bs
+++ b/index.bs
@@ -2661,8 +2661,8 @@ Council Deliberations</h5>
 	after sufficient deliberation,
 	and with due consideration of each argument in the applicable [=Formal Objections=],
 	the [=W3C Council=] decides whether to
-	<dfn>confirm</dfn> or <dfn>overturn</dfn> the decision being objected to.
-	The [=W3C Council=] <em class=rfc2119>may</em> [=confirm=] the decision
+	<dfn>uphold</dfn> or <dfn>overturn</dfn> the decision being objected to.
+	The [=W3C Council=] <em class=rfc2119>may</em> [=uphold=] the decision
 	even if it agrees with some of the arguments made as part of a [=Formal Objection=].
 
 	<p id=fo-mitigations>
@@ -2720,7 +2720,7 @@ Council Decision Report</h5>
 
 	A [=Council=] terminates by issuing a <dfn export>Council Report</dfn>,
 	which:
-	* <em class=rfc2119>must</em> state whether the Council [=confirms=] or [=overturns=] the decision being objected to.
+	* <em class=rfc2119>must</em> state whether the Council [=upholds=] or [=overturns=] the decision being objected to.
 	* <em class=rfc2119>must</em> provide a rationale supporting its conclusion,
 		which <em class=rfc2119>should</em> address each argument raised in the Formal Objection(s).
 	* <em class=rfc2119>must</em> include any recommendation decided by the [=Council=].

--- a/index.bs
+++ b/index.bs
@@ -2655,17 +2655,17 @@ Council Deliberations</h5>
 	<p id=broker-consensus>
 	The Council <em class=rfc2119>may</em>
 	further attempt to broker consensus,
-	which, if successful, disposes the formal objection.
+	which, if successful, disposes that formal objection.
 
 	Otherwise,
 	after sufficient deliberation,
 	the [=W3C Council=] decides whether to
-	<dfn lt="uphold | upholds | upheld | upholding">uphold</dfn> or <dfn>overrule</dfn> the objection.
-	The [=W3C Council=] <em class=rfc2119>may</em> [=overrule=] the [=Formal Objection=]
-	even if it agrees with some of the supportive arguments.
+	<dfn>confirm</dfn> or <dfn>overturn</dfn> the decision being objected to.
+	The [=W3C Council=] <em class=rfc2119>may</em> [=confirm=] the decision
+	even if it agrees with some of the arguments of a [=Formal Objection=].
 
 	<p id=fo-mitigations>
-	When [=upholding=] an objection,
+	When [=overturning=] an decision,
 	it <em class=rfc2199>should</em> recommend a way forward.
 	If the overturned decision has already had consequences
 	(e.g., if the objection concerns material already in a published document)
@@ -2701,7 +2701,7 @@ Council Deliberations</h5>
 	not two.
 
 	In the case of non-unanimous decisions,
-	members of a [=W3C Council=] who disagree with the decision
+	members of a [=W3C Council=] who disagree with the Council's decision
 	<em class=rfc2119>may</em> write a <dfn>Minority Opinion</dfn>
 	explaining the reason for their disagreement.
 
@@ -2719,14 +2719,14 @@ Council Decision Report</h5>
 
 	A [=Council=] terminates by issuing a <dfn export>Council Report</dfn>,
 	which:
-	* <em class=rfc2119>must</em> state whether the Council [=upholds=] or [=overrules=] the objection(s).
-	* <em class=rfc2119>must</em> provide a rationale supporting the decision,
+	* <em class=rfc2119>must</em> state whether the Council [=confirms=] or [=overturns=] the decision being objected to.
+	* <em class=rfc2119>must</em> provide a rationale supporting its conclusion,
 		which <em class=rfc2119>should</em> address each argument raised in the Formal Objection(s).
 	* <em class=rfc2119>must</em> include any recommendation decided by the [=Council=].
-	* if the [=Formal Objection=] has been upheld, <em class=rfc2119>should</em> include any suggested <a href="#fo-mitigations">mitigations</a>.
+	* if the decision has been overturned, <em class=rfc2119>should</em> include any suggested <a href="#fo-mitigations">mitigations</a>.
 	* <em class=rfc2119>must</em> include the [=Minority Opinion(s)=], if any.
 	* <em class=rfc2119>must</em> report the names of those who were [=dismissed=] or [=renounced=] their seat as well as those who were qualified to serve.
-	* <em class=rfc2119>must</em> report the names of the individuals who participated in the final decision.
+	* <em class=rfc2119>must</em> report the names of the individuals who participated in the final Council decision.
 	* <em class=rfc2119>must</em> report the number of votes for/against dismissing each participant.
 	* <em class=rfc2119>may</em> report vote totals for the Council’s decision, if a formal vote was held.
 	* <em class=rfc2119>must not</em> attribute any position to any individual on the Council.

--- a/index.bs
+++ b/index.bs
@@ -2659,6 +2659,7 @@ Council Deliberations</h5>
 
 	Otherwise,
 	after sufficient deliberation,
+	and with due consideration of each argument in the applicable [=Formal Objections=],
 	the [=W3C Council=] decides whether to
 	<dfn>confirm</dfn> or <dfn>overturn</dfn> the decision being objected to.
 	The [=W3C Council=] <em class=rfc2119>may</em> [=confirm=] the decision

--- a/index.bs
+++ b/index.bs
@@ -2654,8 +2654,8 @@ Council Deliberations</h5>
 
 	<p id=broker-consensus>
 	The Council <em class=rfc2119>may</em>
-	further attempt to broker consensus,
-	which, if successful, disposes that formal objection.
+	further attempt to broker consensus on one or more of the formal objections,
+	which, if successful, would allow them to be resolved.
 
 	Otherwise,
 	after sufficient deliberation,


### PR DESCRIPTION
Even though the logic already was that the Council processes all objections to a single decision together, parts of the original text were written as if there was only a single objection, and were awkward or in case of several.

This rephrasing makes the text coherent.

See #1041


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1045.html" title="Last updated on Jun 11, 2025, 3:10 PM UTC (ac10398)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1045/2691bf7...frivoal:ac10398.html" title="Last updated on Jun 11, 2025, 3:10 PM UTC (ac10398)">Diff</a>