### PR TITLE
Clarify timing of Council being convened

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2630,8 +2630,9 @@ Council Chairing</h5>
 <h5 id=council-convention>
 Convening the Council</h5>
 
-	Upon appointment of the [=W3C Council Chair=]
-	and delivery of the [=Team=]’s report,
+	Once [=dismissal=], [=renunciation=], and
+	appointment of the [=W3C Council Chair=] have concluded,
+	and the [=Team=]’s report has been delivered,
 	the [=W3C Council=] is considered to be <dfn>convened</dfn>
 	and can start [[#council-deliberations|deliberations]].
 

--- a/index.bs
+++ b/index.bs
@@ -2630,7 +2630,7 @@ Council Chairing</h5>
 <h5 id=council-convention>
 Convening the Council</h5>
 
-	Once [=dismissal=], [=renunciation=], and
+	When [=dismissal=], [=renunciation=], and
 	appointment of the [=W3C Council Chair=] have concluded,
 	and the [=Team=]’s report has been delivered,
 	the [=W3C Council=] is considered to be <dfn>convened</dfn>


### PR DESCRIPTION
It is already implied that the Council is only convened after dismissal and renunciation because the chair is picked by members of the council, not potential members, but this is not super clear from this paragraph so make it obvious.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1046.html" title="Last updated on May 13, 2025, 10:36 AM UTC (2b6119b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1046/2691bf7...frivoal:2b6119b.html" title="Last updated on May 13, 2025, 10:36 AM UTC (2b6119b)">Diff</a>