### PR TITLE
Handle votes by >2 council members from the same affiliation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2696,9 +2696,8 @@ Council Deliberations</h5>
 	then members of that group at the time the decision or proposal was made
 	must abstain in such a vote.
 	In case of a vote,
-	if two members of a Council who share the same affiliation cast an identical ballot,
-	then their ballots count as a one vote,
-	not two.
+	if multiple members of a Council who share the same affiliation cast identical ballots,
+	then these identical ballots count as a single vote.
 
 	In the case of non-unanimous decisions,
 	members of a [=W3C Council=] who disagree with the decision


### PR DESCRIPTION
In rare cases, there can be more than 2 members of the council with the same affiliation. Generalize the phrasing about votes to handle that too.

See #1018


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1047.html" title="Last updated on May 13, 2025, 4:25 AM UTC (5369982)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1047/2691bf7...frivoal:5369982.html" title="Last updated on May 13, 2025, 4:25 AM UTC (5369982)">Diff</a>