### PR TITLE
More explicitly allow removal of AB/TAG members for violation of the Code of Conduct

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1329,8 +1329,12 @@ Removing AB or TAG members</h5>
 	Individual participants of the [=Advisory Board=] or the [=Technical Architecture Group=]
 	can be <dfn export lt="remove|removal">removed</dfn> from those groups
 	if they are found by their peers
-	to be grossly neglecting their duties,
-	or to be acting in a way that seriously hampers the group's ability to function.
+	to be grossly neglecting their duties
+	or acting in a way that seriously hampers the group's ability to function;
+	or if they are violating policies or other standards of behavior
+	(such as applicable laws or the <a href="https://www.w3.org/policies/code-of-conduct/#Reporting">Code of Conduct</a>)
+	in a way that significantly impacts the safety or integrity
+	of W3C or its community.
 
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold a hearing
 	on the potential [=removal=] of a participant


### PR DESCRIPTION
This wording has two goals:
1. Make it clear that members can be removed for Code of Conduct violations.
2. Make it clear that minor transgressions are not enough to cause removal.

Relates to #882

---- 

This is split from #1036, to facilitate discussion of the various independent aspects of that PR. See https://github.com/w3c/process/pull/1036/commits/7c32000c85e4cc3777aa354979e63a5a59359c8e#r2064384283 for prior discussion on this particular aspect. 

This PRs is against the ab-tag-discipline topic branch ([source](https://github.com/w3c/process/tree/ab-tag-discipline), [preview](https://www.w3.org/policies/process/drafts/ab-tag-discipline/)), not the main branch, meaning we can iterate and accept individual pieces, and still have a chance at the end to judge the combined result before we decide whether to merge it.