### PR TITLE
Define removal hearings as private, and removal votes by secret ballot.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1332,12 +1332,12 @@ Removing AB or TAG members</h5>
 	to be grossly neglecting their duties,
 	or to be acting in a way that seriously hampers the group's ability to function.
 
-	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold a hearing
+	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold an <i>in camera</i> hearing
 	on the potential [=removal=] of a participant
 	if requested by at least three of the participants in the group.
 	After giving the individual in question
 	an opportunity to defend themselves,
-	a vote on the proposed [=removal=] is held.
+	a vote on the proposed [=removal=] is held by secret ballot.
 	If at least three quarters of the participants in the group,
 	excluding the individual who is the subject of such vote,
 	then vote in favor of the proposal,


### PR DESCRIPTION
Addresses part of #1007

----

This is split from #1036, to facilitate discussion of the various independent aspects of that PR.

This PRs is against the ab-tag-discipline topic branch ([source](https://github.com/w3c/process/tree/ab-tag-discipline), [preview](https://www.w3.org/policies/process/drafts/ab-tag-discipline/)), not the main branch, meaning we can itterate and accept individual pieces, and still have a chance at the end to judge the combined result before we decide whether to merge it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1049.html" title="Last updated on May 14, 2025, 8:36 AM UTC (736f775)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1049/f18078b...frivoal:736f775.html" title="Last updated on May 14, 2025, 8:36 AM UTC (736f775)">Diff</a>