### PR TITLE
Require attempted remediation before removal from the AB or TAG.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1331,6 +1331,8 @@ Removing AB or TAG members</h5>
 	if they are found by their peers
 	to be grossly neglecting their duties,
 	or to be acting in a way that seriously hampers the group's ability to function.
+	Removal <em class=rfc2119>should</em> be a last resort,
+	after reasonable attempts at remediation have failed.
 
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold a hearing
 	on the potential [=removal=] of a participant


### PR DESCRIPTION
This is split from #1036, to facilitate discussion of the various independent aspects of that PR.

This PRs is against the ab-tag-discipline topic branch ([source](https://github.com/w3c/process/tree/ab-tag-discipline), [preview](https://www.w3.org/policies/process/drafts/ab-tag-discipline/)), not the main branch, meaning we can itterate and accept individual pieces, and still have a chance at the end to judge the combined result before we decide whether to merge it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1050.html" title="Last updated on May 15, 2025, 3:06 PM UTC (7e27b46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1050/f18078b...frivoal:7e27b46.html" title="Last updated on May 15, 2025, 3:06 PM UTC (7e27b46)">Diff</a>