### PR TITLE
TAG/AB and CEO removal integration (Second Draft)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -462,7 +462,7 @@ Expectations and Discipline</h5>
 
 	The [=CEO=] <em class="rfc2119">may</em> take disciplinary action,
 	including suspending or removing for cause
-	a participant in any group (including the [=AB=] and [=TAG=])
+	any participant from any group (except [=elected groups=])
 	if serious and/or repeated violations,
 	such as failure to meet the requirements on individual behavior of
 	(a) this process
@@ -471,6 +471,7 @@ Expectations and Discipline</h5>
 	(c) applicable laws,
 	occur.
 	Refer to the <a href="https://www.w3.org/guide/process/suspension">Guidelines to suspend or remove participants from groups</a>.
+	See [[#AB-TAG-removal]] for removal from an [=elected group=].
 
 <h5 id="coi">
 Conflict of Interest Policy</h5>
@@ -1334,17 +1335,26 @@ Removing AB or TAG members</h5>
 
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold a hearing
 	on the potential [=removal=] of a participant
-	if requested by at least three of the participants in the group.
+	if requested by at least three of the participants in the group
+	or if requested by a [=Team decision=]
+	(which must provide rationale for such [[#discipline|disciplinary action]]).
 	After giving the individual in question
 	an opportunity to defend themselves,
 	a vote on the proposed [=removal=] is held.
 	If at least three quarters of the participants in the group,
-	excluding the individual who is the subject of such vote,
+	excluding the individual who is the subject of such vote--
+	or two thirds, in the case of a [=Team=] request--
 	then vote in favor of the proposal,
 	the individual's seat on [=AB=] or [=TAG=] is [=vacated=] immediately.
 	The group must notify the [=AC=] of such a [=removal=] within one week.
 
 	Note: Removal from the [=AB=] or [=TAG=] does not imply removal from a convened [=Council=].
+
+	In extraordinary cases where the group refuses or is unable to act,
+	but the [=Team=] decides that removal is necessary to protect W3C or its community members,
+	the [=CEO=] <em class=rfc2119>may</em>
+	remove a participant of the [=AB=] or [=TAG=]
+	with the approval of the Board of Directors.
 
 <h5 id="AB-TAG-vacated">
 Elected Groups Vacated Seats</h5>

--- a/index.bs
+++ b/index.bs
@@ -1336,7 +1336,7 @@ Removing AB or TAG members</h5>
 	The [=AB=] or [=TAG=] <em class=rfc2119>must</em> hold a hearing
 	on the potential [=removal=] of a participant
 	if requested by at least three of the participants in the group
-	or if requested by a [=Team decision=]
+	or if requested by the [=Team=]
 	(which must provide rationale for such [[#discipline|disciplinary action]]).
 	After giving the individual in question
 	an opportunity to defend themselves,

--- a/index.bs
+++ b/index.bs
@@ -1358,7 +1358,7 @@ Removing AB or TAG members</h5>
 	remove a participant of the [=AB=] or [=TAG=]
 	with the approval of the Board of Directors.
 
-        
+
 <h5 id="AB-TAG-recall">
 AC Recall of AB or TAG</h5>
 


### PR DESCRIPTION
* Removes the CEO's ability to unilaterally remove a member of the AB or TAG.
* Allows the Team to request the AB or TAG to initiate removal of a member, and reduces the vote threshold in such cases.
* Allows the CEO + Board of Directors, as a secondary route of action, to remove participants when necessary.

Relates to #882

This approach is an attempt at finding a compromise: at least one AB participant has expressed wanting the CEO's removal power to be replaced by AB/TAG removal, and while another wants to keep both (partly to have a second pathway in case one is blocked). This attempts to find a third way that both could live with. Reluctance in involving the board has been noted as well ([1](https://github.com/w3c/process/pull/1036#issuecomment-2845023095), [2](https://github.com/w3c/process/pull/1036#issuecomment-2849305481)), in response to an [earlier draft](https://github.com/w3c/process/commit/b81ccf361c8391b97637d0e57ee8e12ded94cc12) relying solely on the Board of Directors.

----

This is split from #1036, to facilitate discussion of the various independent aspects of that PR. See https://github.com/w3c/process/pull/1036/files#r2079248832 and https://github.com/w3c/process/pull/1036/files#r2064388077 for prior discussion on this particular aspect.

This PRs is against the ab-tag-discipline topic branch ([source](https://github.com/w3c/process/tree/ab-tag-discipline), [preview](https://www.w3.org/policies/process/drafts/ab-tag-discipline/)), not the main branch, meaning we can itterate and accept individual pieces, and still have a chance at the end to judge the combined result before we decide whether to merge it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1052.html" title="Last updated on Sep 25, 2025, 7:30 AM UTC (835ca85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1052/506f958...frivoal:835ca85.html" title="Last updated on Sep 25, 2025, 7:30 AM UTC (835ca85)">Diff</a>