### PR TITLE
Drop legacy aliases for Group Note from the definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4553,7 +4553,7 @@ The Note Track (Notes and Statements)</h3>
 <h4 id="Note">
 Group Notes</h4>
 
-	A <dfn export id="WGNote" lt="Group Note | Note | W3C Note | Working Group Note | Interest Group Note | AB Note | TAG Note">Group Note</dfn> (<abbr>NOTE</abbr>)
+	A <dfn export id="WGNote" lt="Group Note | Note">Group Note</dfn> (<abbr>NOTE</abbr>)
 	is published
 	to provide a stable reference for a useful document
 	that is not intended to be a formal standard.
@@ -5627,9 +5627,9 @@ Changes since the <a href="https://www.w3.org/policies/process/20231103/">3 Nove
 				<li>
 					<strong>
 					Retire the Proposed Recommendation phase of the Recommendation track.
+					</strong>
 					It was only used as a short-lived transition
 					during which various verifications and votes about CR were done.
-					</strong>
 					These can be done on a CR
 					without having to republish it as a separate thing.
 					This simplifies the Process without changing the actual quality or consensus expectations.

--- a/snapshots/2025-05.html
+++ b/snapshots/2025-05.html
@@ -4964,9 +4964,9 @@ on addressing issues raised by individuals external to the Group.</p>
      <dt id="changes-2025-tr"><a class="self-link" href="#changes-2025-tr"></a>Changes to technical reports and their publication 
      <dd>
       <ul>
-       <li> <strong> Retire the Proposed Recommendation phase of the Recommendation track.
-					It was only used as a short-lived transition
-					during which various verifications and votes about CR were done. </strong> These can be done on a CR
+       <li> <strong> Retire the Proposed Recommendation phase of the Recommendation track. </strong> It was only used as a short-lived transition
+					during which various verifications and votes about CR were done.
+					These can be done on a CR
 					without having to republish it as a separate thing.
 					This simplifies the Process without changing the actual quality or consensus expectations.
 					(See <a href="https://github.com/w3c/process/issues/861">Issue 861</a>) 


### PR DESCRIPTION
These names were only provided as a bikeshed convenience, but it is unlikely that it is being used, and defining them gives them exposure in the "terms defined by this specification" index. Giving exposure to legacy terms is unnecessary and confusing, so removing.

Addresses #1064


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1067.html" title="Last updated on Jun 10, 2025, 4:39 AM UTC (7b8fccd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1067/4cbc515...frivoal:7b8fccd.html" title="Last updated on Jun 10, 2025, 4:39 AM UTC (7b8fccd)">Diff</a>