### PR TITLE
Remove AB Liaisons to the Board

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -961,25 +961,6 @@ Communications of the Advisory Board</h5>
 	The Advisory Board <em class="rfc2119">should</em> also report on its activities
 	at each <a href="#ACMeetings">Advisory Committee meeting</a>.
 
-<h5 id=ab-bod-liaison>
-Liaisons between the Advisory Board and the Board of Directors</h5>
-
-	To ensure good communication between the [=AB=] and the [=Board of Directors=]
-	and facilitate operational and management consistency,
-	the [=AB=] <em class=rfc2119>may</em> appoint up to two of its participants as liaisons to the [=Board=].
-	Such appointees are expected to attend and participate in [=Board=] meetings
-	and access [=Board=] materials
-	as Non-voting Observers. [[BYLAWS]]
-	They do not form part of the [=Board=]'s decision-making body,
-	and may be excluded from such participation
-	in accordance with applicable Board procedures.
-
-	The [=Advisory Board=] <em class=rfc2119>should</em> reevaluate
-	who is assigned to this role
-	at least at the beginning of each term,
-	and <em class=rfc2119>may</em> swap its appointees more frequently
-	as they deem appropriate.
-
 <h4 id="TAG">
 Technical Architecture Group (TAG)</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -5407,6 +5407,12 @@ Appendix A: Retired Terminology</h2>
 		<dd>
 			Last defined <a href="https://www.w3.org/2005/10/Process-20051014/tr.html#last-call">in section 7.4.2 of the 2005 Process</a>.
 
+		<dt>Liaisons between the Advisory Board and the Board of Directors,
+			also known as <i id="ab-bod-liaison">AB Liaisons</i>
+			(retired concept)
+		<dd>
+			Last covered <a href="https://www.w3.org/policies/process/20250818/#ab-bod-liaison">in section 3.3.1.4 of the 2025 Process</a>.
+
 		<dt>
 			<dfn noexport id=maturity-levels>Maturity level</dfn>
 			(renamed term)


### PR DESCRIPTION
The Board has terminated the AB Liaison program, as reported in https://www.w3.org/Member/bod/meetings/board/2025/2025-11-09/minutes.html#improving-collaboration-with-the-ab.

Remove the corresponding Process provisions, as they are not ineffective.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/w3process/pull/1179.html" title="Last updated on Jul 10, 2026, 10:22 AM UTC (80cd669)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1179/658acd5...frivoal:80cd669.html" title="Last updated on Jul 10, 2026, 10:22 AM UTC (80cd669)">Diff</a>