### PR TITLE
Refine Advisory Board and TAG chair selection process

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1360,7 +1360,7 @@ Elected Groups Chair Selection</h5>
 
 	Participants in the [=AB=] and [=TAG=] choose by consensus their Chair or co-Chairs;
 	in the absence of consensus, the [=Team=] appoints the Chair or co-Chairs of the group.
-	The Chair or co-Chairs <em class="rfc2119">must</em> be selected from the participants of the group.
+	At least one of the Chair or co-Chairs <em class="rfc2119">must</em> be selected from the participants of the group.
 	Chair selection <em class=rfc2119>must</em> be run
 	at least at the start of each regular term,
 	as well as when a majority of the participants request it;

--- a/index.bs
+++ b/index.bs
@@ -919,7 +919,7 @@ Role of the Advisory Board</h5>
 <h5 id="ABParticipation">
 Composition of the Advisory Board</h5>
 
-The [=Advisory Board=] consists of nine to eleven elected participants.
+	The [=Advisory Board=] consists of nine to eleven elected participants.
 	
 	The team appoints a [=Staff Contact=],
 	as described in <a href="#ReqsAllGroups"></a>.

--- a/index.bs
+++ b/index.bs
@@ -919,8 +919,7 @@ Role of the Advisory Board</h5>
 <h5 id="ABParticipation">
 Composition of the Advisory Board</h5>
 
-	The [=Advisory Board=] consists of nine to eleven elected participants and one Chair
-	(who <em class=rfc2119>may</em> be one of the elected participants).
+The [=Advisory Board=] consists of nine to eleven elected participants.
 	
 	The team appoints a [=Staff Contact=],
 	as described in <a href="#ReqsAllGroups"></a>.

--- a/index.bs
+++ b/index.bs
@@ -745,7 +745,7 @@ Role of the Advisory Committee</h4>
 			and <a href="#GAProcess">proposed Process Documents</a>.
 
 		<li>
-			electing the <a href="#AB">Advisory Board</a> participants other than the Advisory Board Chair.
+			electing the <a href="#AB">Advisory Board</a> participants.
 
 		<li>
 			electing a majority (6) of the participants on the <a href="#TAG">Technical Architecture Group</a>.
@@ -921,19 +921,8 @@ Composition of the Advisory Board</h5>
 
 	The [=Advisory Board=] consists of nine to eleven elected participants and one Chair
 	(who <em class=rfc2119>may</em> be one of the elected participants).
-	With the input of the [=AB=],
-	the [=Team=] appoints the Chair,
-	who <em class=rfc2119>should</em> choose a co-chair among the elected participants.
-	Upon appointment,
-	the Chair(s) are subject to ratification by secret ballot,
-	requiring approval by two thirds of the elected participants.
-	Chair selection <em class=rfc2119>must</em> be run
-	at least at the start of each regular term,
-	as well as when a majority of the participants request it;
-	and <em class=rfc2119>may</em> be run at other times when initiated by the current chairs or the Team,
-	for example if a chair steps down or if a minority of the participants make such a request.
-
-	The team also appoints a [=Staff Contact=],
+	
+	The team appoints a [=Staff Contact=],
 	as described in <a href="#ReqsAllGroups"></a>.
 	The CEO and Staff Contact have a standing invitation
 	to all regular Advisory Board sessions.
@@ -1022,16 +1011,7 @@ Composition of the Technical Architecture Group</h5>
 			following the <a href="#AB-TAG-elections">AB/TAG nomination and election process</a>.
 	</ul>
 
-	Participants in the [=TAG=] choose by consensus their Chair or co-Chairs;
-	in the absence of consensus, the [=Team=] appoints the Chair or co-Chairs of the TAG.
-	The Chair or co-Chairs <em class="rfc2119">must</em> be selected from the participants of the TAG.
-	Chair selection <em class=rfc2119>must</em> be run
-	at least at the start of each regular term,
-	as well as when a majority of the participants request it;
-	and <em class=rfc2119>may</em> be run at other times when initiated by the current chairs or the Team,
-	for example if a chair steps down or if a minority of the participants make such a request.
-
-	The [=Team=] also appoints a <a href="https://www.w3.org/guide/teamcontact/role">Staff Contact</a> [[TEAM-CONTACT]] for the TAG,
+	The [=Team=] appoints a <a href="https://www.w3.org/guide/teamcontact/role">Staff Contact</a> [[TEAM-CONTACT]] for the TAG,
 	as described in <a href="#ReqsAllGroups"></a>.
 
 	The terms of TAG participants last for <span class="time-interval">two years</span>.
@@ -1374,6 +1354,18 @@ Elected Groups Vacated Seats</h5>
 			Except for the number of available seats and the length of the terms,
 			the <a href="#AB-TAG-elections">usual rules for Advisory Board and Technical Architecture Group Elections</a> apply.
 	</ul>
+
+<h5 id="AB-TAG-chairs">
+Elected Groups Chair Selection</h5>
+
+	Participants in the [=AB=] and [=TAG=] choose by consensus their Chair or co-Chairs;
+	in the absence of consensus, the [=Team=] appoints the Chair or co-Chairs of the group.
+	The Chair or co-Chairs <em class="rfc2119">must</em> be selected from the participants of the group.
+	Chair selection <em class=rfc2119>must</em> be run
+	at least at the start of each regular term,
+	as well as when a majority of the participants request it;
+	and <em class=rfc2119>may</em> be run at other times when initiated by the current chairs or the Team,
+	for example if a chair steps down or if a minority of the participants make such a request.
 
 <h3 id="GAGeneral" oldids="ChapterGroups, WG-and-IG">
 Chartered Groups: Working Groups and Interest Groups</h3>


### PR DESCRIPTION
Removed redundant text regarding Advisory Board Chair selection and clarified the appointment process for Staff Contact. As per #1182. This is my first PR on the Process so please bear with me if the formatting is not what it should be.

Open issues on this PR:

- The current wording of the combined text says that the chair MUST be selected from the group in question, but this is not the case for the AB, so should this must actually be a SHOULD (opening up the possibility of an external chair for the TAG as well) or should there be separate language in here for TAG and AB?
- The AB chair selection process includes a separate ratification step by secret ballot: "Upon appointment, the Chair(s) are subject to ratification by secret ballot, requiring approval by two thirds of the elected participants." Should this be a part of the combined text, or do we leave it to each group to develop their own agreed way to measure the consensus decision?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/process/pull/1183.html" title="Last updated on Aug 26, 2026, 2:42 PM UTC (1895a32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/process/1183/13f4d5b...1895a32.html" title="Last updated on Aug 26, 2026, 2:42 PM UTC (1895a32)">Diff</a>